### PR TITLE
DXVK Async Toggle

### DIFF
--- a/Whisky/Views/Bottle Views/ConfigView.swift
+++ b/Whisky/Views/Bottle Views/ConfigView.swift
@@ -98,11 +98,9 @@ struct ConfigView: View {
                     Toggle(isOn: $bottle.settings.dxvk) {
                         Text("config.dxvk")
                     }
-
                     Toggle(isOn: $bottle.settings.dxvk) {
                         Text("config.dxvk.async")
                     }
-                    
                     Picker("config.dxvkHud", selection: $bottle.settings.dxvkHud) {
                         Text("config.dxvkHud.full").tag(DXVKHUD.full)
                         Text("config.dxvkHud.partial").tag(DXVKHUD.partial)

--- a/Whisky/Views/Bottle Views/ConfigView.swift
+++ b/Whisky/Views/Bottle Views/ConfigView.swift
@@ -98,6 +98,11 @@ struct ConfigView: View {
                     Toggle(isOn: $bottle.settings.dxvk) {
                         Text("config.dxvk")
                     }
+
+                    Toggle(isOn: $bottle.settings.dxvk) {
+                        Text("config.dxvk.async")
+                    }
+                    
                     Picker("config.dxvkHud", selection: $bottle.settings.dxvkHud) {
                         Text("config.dxvkHud.full").tag(DXVKHUD.full)
                         Text("config.dxvkHud.partial").tag(DXVKHUD.partial)

--- a/Whisky/en.lproj/Localizable.strings
+++ b/Whisky/en.lproj/Localizable.strings
@@ -44,7 +44,7 @@
 "config.dxvkHud.partial" = "Partial";
 "config.dxvkHud.fps" = "FPS";
 "config.dxvkHud.off" = "Off";
-"config.dxvk.async" = "DXVK ASync";
+"config.dxvk.async" = "DXVK Async";
 "config.dpi" = "DPI Scaling";
 "config.inspect" = "Configure...";
 

--- a/Whisky/en.lproj/Localizable.strings
+++ b/Whisky/en.lproj/Localizable.strings
@@ -44,6 +44,7 @@
 "config.dxvkHud.partial" = "Partial";
 "config.dxvkHud.fps" = "FPS";
 "config.dxvkHud.off" = "Off";
+"config.dxvk.async" = "DXVK ASync";
 "config.dpi" = "DPI Scaling";
 "config.inspect" = "Configure...";
 

--- a/WhiskyKit/Whisky/BottleSettings.swift
+++ b/WhiskyKit/Whisky/BottleSettings.swift
@@ -63,6 +63,7 @@ public struct BottleMetalConfig: Codable {
 
 public struct BottleDXVKConfig: Codable {
     var dxvk: Bool = false
+    var dxvkAsync: Bool = true
     var dxvkHud: DXVKHUD = .off
 }
 
@@ -135,6 +136,14 @@ public class BottleSettings {
         }
         set {
             settings.dxvkConfig.dxvk = newValue
+        }
+    }
+
+    var dxvkAsync: Bool {
+        get {
+            return settings.dxvkConfig.dxvkAsync
+        } set {
+            settings.dxvkConfig.dxvkAsync = newValue
         }
     }
 
@@ -224,6 +233,10 @@ public class BottleSettings {
             case .off:
                 break
             }
+        }
+
+        if dxvkAsync {
+            environment.updateValue("1", forKey: "DXVK_ASYNC")
         }
 
         if esync {


### PR DESCRIPTION
Adds a toggle that enables DXVK Async (by setting DXVK_ASYNC=1) in the bottle settings. Default is `true`.

Preview of toggle:
<img width="736" alt="DXVK Async" src="https://github.com/Whisky-App/Whisky/assets/87151697/fd4c64f6-6472-4a82-9da0-e7ce39061856">


