### PR TITLE
Change Accent Color to Orange

### DIFF
--- a/Whisky/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Whisky/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,6 +1,10 @@
 {
   "colors" : [
     {
+      "color" : {
+        "platform" : "universal",
+        "reference" : "systemOrangeColor"
+      },
       "idiom" : "universal"
     }
   ],


### PR DESCRIPTION
An orange accent color would fit better with the app icon and general theme of Whisky.


Preview:
<img width="1012" alt="Screenshot taken on 2023-09-15 at 10 49 30" src="https://github.com/Whisky-App/Whisky/assets/87151697/797ad6ac-1868-48f1-9514-4ab83d282b26">
<img width="727" alt="Screenshot taken on 2023-09-15 at 10 49 43" src="https://github.com/Whisky-App/Whisky/assets/87151697/a237b15a-ea99-4cd6-91c2-094faf8cffca">
<img width="734" alt="Screenshot taken on 2023-09-15 at 10 49 48" src="https://github.com/Whisky-App/Whisky/assets/87151697/d21f92bd-92fd-4b28-ae59-af3bbbf273ec">
<img width="188" alt="Screenshot taken on 2023-09-15 at 10 49 54" src="https://github.com/Whisky-App/Whisky/assets/87151697/af736767-bb08-471d-bf07-b2f1cdf1cdb5">
