### PR TITLE
Fix external drive problem (#449)

### DIFF
--- a/Whisky/View Models/BottleVM.swift
+++ b/Whisky/View Models/BottleVM.swift
@@ -31,6 +31,10 @@ class BottleVM: ObservableObject {
         bottles = bottlesList.loadBottles()
     }
 
+    func countActive() -> Int {
+        return bottles.filter { $0.isActive == true}.count
+    }
+
     func createNewBottle(bottleName: String, winVersion: WinVersion, bottleURL: URL) -> URL {
         let newBottleDir = bottleURL.appending(path: UUID().uuidString)
 

--- a/Whisky/Views/Bottle Views/BottleView.swift
+++ b/Whisky/Views/Bottle Views/BottleView.swift
@@ -131,6 +131,7 @@ struct BottleView: View {
                 }
                 .padding()
             }
+            .disabled(!bottle.isActive)
             .navigationTitle(bottle.settings.name)
             .sheet(isPresented: $showWinetricksSheet) {
                 WinetricksView(bottle: bottle)

--- a/Whisky/Views/ContentView.swift
+++ b/Whisky/Views/ContentView.swift
@@ -31,6 +31,7 @@ struct ContentView: View {
     @State var showBottleSelection: Bool = false
     @State var newlyCreatedBottleURL: URL?
     @State var openedFileURL: URL?
+    @State var refresh: Bool = false
 
     var body: some View {
         NavigationSplitView {
@@ -46,7 +47,7 @@ struct ContentView: View {
                             .opacity(0.5)
                             .id(bottle.url)
                         } else {
-                            BottleListEntry(bottle: bottle, selected: $selected)
+                            BottleListEntry(bottle: bottle, selected: $selected, refresh: $refresh)
                                 .id(bottle.url)
                                 .selectionDisabled(!bottle.isActive)
                         }
@@ -101,6 +102,15 @@ struct ContentView: View {
                 } label: {
                     Image(systemName: "plus")
                         .help("button.createBottle")
+                }
+            }
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    bottleVM.loadBottles()
+                    refresh.toggle()
+                } label: {
+                    Image(systemName: "arrow.triangle.2.circlepath")
+                        .help("button.refresh")
                 }
             }
         }
@@ -169,11 +179,15 @@ struct BottleListEntry: View {
     @State var showBottleRename: Bool = false
     @State var name: String = ""
     @Binding var selected: URL?
+    @Binding var refresh: Bool
 
     var body: some View {
         Text(name)
             .opacity(bottle.isActive ? 1.0 : 0.5)
             .onAppear {
+                name = bottle.settings.name
+            }
+            .onChange(of: refresh) {
                 name = bottle.settings.name
             }
             .sheet(isPresented: $showBottleRename) {

--- a/Whisky/da.lproj/Localizable.strings
+++ b/Whisky/da.lproj/Localizable.strings
@@ -13,6 +13,7 @@
 "button.exportBottle" = "Export as Archive...";
 "button.removeAlert" = "Fjern...";
 "button.createBottle" = "Opret Bottle";
+"button.refresh" = "Opfrisk";
 "button.removeAlert.msg" = "Fjern %@?";
 "button.removeAlert.info" = "Er du sikker på, at du vil fjerne denne flaske? Denne handling er permanent.";
 "button.removeAlert.checkbox" = "Slet filer fra disk";

--- a/Whisky/de.lproj/Localizable.strings
+++ b/Whisky/de.lproj/Localizable.strings
@@ -13,6 +13,7 @@
 "button.exportBottle" = "Als Archiv exportieren...";
 "button.removeAlert" = "Löschen...";
 "button.createBottle" = "Bottle erstellen";
+"button.refresh" = "Aktualisieren";
 "button.removeAlert.msg" = "%@ löschen?";
 "button.removeAlert.info" = "Sind Sie sicher, dass Sie diese Bottle löschen möchten? Dies kann nicht rückgängig gemacht werden.";
 "button.removeAlert.checkbox" = "Dateien von der Festplatte löschen";

--- a/Whisky/en.lproj/Localizable.strings
+++ b/Whisky/en.lproj/Localizable.strings
@@ -13,6 +13,7 @@
 "button.exportBottle" = "Export as Archive...";
 "button.removeAlert" = "Remove...";
 "button.createBottle" = "Create Bottle";
+"button.refresh" = "Refresh";
 "button.removeAlert.msg" = "Remove %@?";
 "button.removeAlert.info" = "Are you sure you want to remove this bottle? This action is permanent.";
 "button.removeAlert.checkbox" = "Delete files from disk";

--- a/Whisky/es.lproj/Localizable.strings
+++ b/Whisky/es.lproj/Localizable.strings
@@ -13,6 +13,7 @@
 "button.exportBottle" = "Export as Archive...";
 "button.removeAlert" = "Borrar...";
 "button.createBottle" = "Crear Botella";
+"button.refresh" = "Actualizar";
 "button.removeAlert.msg" = "Borrar %@?";
 "button.removeAlert.info" = "¿Estás seguro de que quieres eliminar esta botella? Esta acción es permanente.";
 "button.removeAlert.checkbox" = "Borrar archivos del disco";

--- a/Whisky/fi.lproj/Localizable.strings
+++ b/Whisky/fi.lproj/Localizable.strings
@@ -13,6 +13,7 @@
 "button.exportBottle" = "Vie arkistona...";
 "button.removeAlert" = "Poista...";
 "button.createBottle" = "Luo pullo";
+"button.refresh" = "Päivitä";
 "button.removeAlert.msg" = "Poista %@?";
 "button.removeAlert.info" = "Oletko varma, että haluat poistaa tämän pullon? Tämä toiminto on pysyvä.";
 "button.removeAlert.checkbox" = "Poista tiedostoja levyltä";

--- a/Whisky/fr.lproj/Localizable.strings
+++ b/Whisky/fr.lproj/Localizable.strings
@@ -13,6 +13,7 @@
 "button.exportBottle" = "Export as Archive...";
 "button.removeAlert" = "Supprimer...";
 "button.createBottle" = "Créer une bouteille";
+"button.refresh" = "Rafraîchir";
 "button.removeAlert.msg" = "Supprimer %@?";
 "button.removeAlert.info" = "Êtes-vous sûr de vouloir supprimer cette bouteille ? Cette action est définitive.";
 "button.removeAlert.checkbox" = "Supprimer les fichiers du disque";

--- a/Whisky/it.lproj/Localizable.strings
+++ b/Whisky/it.lproj/Localizable.strings
@@ -13,6 +13,7 @@
 "button.exportBottle" = "Export as Archive...";
 "button.removeAlert" = "Rimuovi...";
 "button.createBottle" = "Crea Bottiglia";
+"button.refresh" = "Aggiornare";
 "button.removeAlert.msg" = "Vuoi rimuovere %@?";
 "button.removeAlert.info" = "Sei sicuro di voler eliminare questa bottle? L'azione è permanente.";
 "button.removeAlert.checkbox" = "Elimina i file dal disco";

--- a/Whisky/ja.lproj/Localizable.strings
+++ b/Whisky/ja.lproj/Localizable.strings
@@ -13,6 +13,7 @@
 "button.exportBottle" = "アーカイブとしてエクスポート...";
 "button.removeAlert" = "削除...";
 "button.createBottle" = "Bottle を作成";
+"button.refresh" = "リフレッシュ";
 "button.removeAlert.msg" = "%@ を削除しますか？";
 "button.removeAlert.info" = "この Bottle を削除してもよろしいですか？ この操作は取り消せません。";
 "button.removeAlert.checkbox" = "ディスクからも削除";

--- a/Whisky/ko.lproj/Localizable.strings
+++ b/Whisky/ko.lproj/Localizable.strings
@@ -13,6 +13,7 @@
 "button.exportBottle" = "아카이브로 내보내기...";
 "button.removeAlert" = "삭제...";
 "button.createBottle" = "Bottle 생성";
+"button.refresh" = "새로 고침";
 "button.removeAlert.msg" = "%@을(를) 삭제하시겠습니까?";
 "button.removeAlert.info" = "정말로 이 Bottle을 삭제하시겠습니까? 이 행동은 되돌릴 수 없습니다.";
 "button.removeAlert.checkbox" = "디스크에서 파일 삭제";

--- a/Whisky/nl.lproj/Localizable.strings
+++ b/Whisky/nl.lproj/Localizable.strings
@@ -13,6 +13,7 @@
 "button.exportBottle" = "Export as Archive...";
 "button.removeAlert" = "Remove...";
 "button.createBottle" = "Fles maken";
+"button.refresh" = "Vernieuw";
 "button.removeAlert.msg" = "Remove %@?";
 "button.removeAlert.info" = "Are you sure you want to remove this bottle? This action is permanent.";
 "button.removeAlert.checkbox" = "Delete files from disk";

--- a/Whisky/pl.lproj/Localizable.strings
+++ b/Whisky/pl.lproj/Localizable.strings
@@ -13,6 +13,7 @@
 "button.exportBottle" = "Eksportuj jako archiwum...";
 "button.removeAlert" = "Usuń...";
 "button.createBottle" = "Utwórz butelkę";
+"button.refresh" = "Odśwież";
 "button.removeAlert.msg" = "Usunąć %@?";
 "button.removeAlert.info" = "Czy na pewno chcesz usunąć tę butelkę? Ta akcja jest nieodwracalna.";
 "button.removeAlert.checkbox" = "Usuń pliki z dysku";

--- a/Whisky/pt-BR.lproj/Localizable.strings
+++ b/Whisky/pt-BR.lproj/Localizable.strings
@@ -13,6 +13,7 @@
 "button.exportBottle" = "Exportar como arquivo...";
 "button.removeAlert" = "Remover...";
 "button.createBottle" = "Criar uma Bottle";
+"button.refresh" = "Atualizar";
 "button.removeAlert.msg" = "Remover %@?";
 "button.removeAlert.info" = "Tem a certeza de que pretende remover esta garrafa? Esta ação é permanente.";
 "button.removeAlert.checkbox" = "Apagar arquivos do disco";

--- a/Whisky/pt-PT.lproj/Localizable.strings
+++ b/Whisky/pt-PT.lproj/Localizable.strings
@@ -13,6 +13,7 @@
 "button.exportBottle" = "Export as Archive...";
 "button.removeAlert" = "Remove...";
 "button.createBottle" = "Criar uma Bottle";
+"button.refresh" = "Atualizar";
 "button.removeAlert.msg" = "Remove %@?";
 "button.removeAlert.info" = "Are you sure you want to remove this bottle? This action is permanent.";
 "button.removeAlert.checkbox" = "Delete files from disk";

--- a/Whisky/ru.lproj/Localizable.strings
+++ b/Whisky/ru.lproj/Localizable.strings
@@ -13,6 +13,7 @@
 "button.exportBottle" = "Экспортировать как архив...";
 "button.removeAlert" = "Удалить...";
 "button.createBottle" = "Создать Бутылку";
+"button.refresh" = "Обновить";
 "button.removeAlert.msg" = "Удалить %@?";
 "button.removeAlert.info" = "Вы уверены, что хотите удалить эту бутылку? Это действие необратимо.";
 "button.removeAlert.checkbox" = "Удалить файлы с диска";

--- a/Whisky/tr.lproj/Localizable.strings
+++ b/Whisky/tr.lproj/Localizable.strings
@@ -13,6 +13,7 @@
 "button.exportBottle" = "Arşiv olarak dışa aktarın...";
 "button.removeAlert" = "Kaldır...";
 "button.createBottle" = "Bottle Oluştur";
+"button.refresh" = "Yenile";
 "button.removeAlert.msg" = "%@ öğesini kaldır?";
 "button.removeAlert.info" = "Bu Bottle'ı kaldırmak istediğinize emin misiniz? Bu hareket kalıcıdır.";
 "button.removeAlert.checkbox" = "Dosyaları diskten sil";

--- a/Whisky/uk.lproj/Localizable.strings
+++ b/Whisky/uk.lproj/Localizable.strings
@@ -13,6 +13,7 @@
 "button.exportBottle" = "Експортувати як архів...";
 "button.removeAlert" = "Видалити...";
 "button.createBottle" = "Створити пляшку";
+"button.refresh" = "Оновити";
 "button.removeAlert.msg" = "Видалити %@?";
 "button.removeAlert.info" = "Ви впевнені, що хочете видалити цю пляшку? Цю дію не можна скасувати.";
 "button.removeAlert.checkbox" = "Видалити файли з диска";

--- a/Whisky/vi.lproj/Localizable.strings
+++ b/Whisky/vi.lproj/Localizable.strings
@@ -13,6 +13,7 @@
 "button.exportBottle" = "Export as Archive...";
 "button.removeAlert" = "Remove...";
 "button.createBottle" = "Tạo Bottle";
+"button.refresh" = "Làm cho khỏe lại";
 "button.removeAlert.msg" = "Remove %@?";
 "button.removeAlert.info" = "Are you sure you want to remove this bottle? This action is permanent.";
 "button.removeAlert.checkbox" = "Delete files from disk";

--- a/Whisky/zh-Hans.lproj/Localizable.strings
+++ b/Whisky/zh-Hans.lproj/Localizable.strings
@@ -13,6 +13,7 @@
 "button.exportBottle" = "Export as Archive...";
 "button.removeAlert" = "删除...";
 "button.createBottle" = "创建容器";
+"button.refresh" = "刷新";
 "button.removeAlert.msg" = "删除 %@？";
 "button.removeAlert.info" = "你确定要删除这个容器吗？这将是不可逆的。";
 "button.removeAlert.checkbox" = "从磁盘中删除文件";

--- a/Whisky/zh-Hant.lproj/Localizable.strings
+++ b/Whisky/zh-Hant.lproj/Localizable.strings
@@ -13,6 +13,7 @@
 "button.exportBottle" = "匯出為封存...";
 "button.removeAlert" = "Remove...";
 "button.createBottle" = "建立容器";
+"button.refresh" = "刷新";
 "button.removeAlert.msg" = "Remove %@?";
 "button.removeAlert.info" = "Are you sure you want to remove this bottle? This action is permanent.";
 "button.removeAlert.checkbox" = "Delete files from disk";

--- a/WhiskyKit/Whisky/Bottle.swift
+++ b/WhiskyKit/Whisky/Bottle.swift
@@ -34,16 +34,21 @@ public class Bottle: Hashable, Identifiable {
     public var settings: BottleSettings
     public var programs: [Program] = []
     public var inFlight: Bool = false
+    public var isActive: Bool = false
 
-    public init(bottleUrl: URL, inFlight: Bool = false) {
+    public init(bottleUrl: URL, inFlight: Bool = false, isActive: Bool = false) {
         self.settings = BottleSettings(bottleURL: bottleUrl)
         self.url = bottleUrl
         self.inFlight = inFlight
+        self.isActive = isActive
     }
 }
 
 extension Array where Element == Bottle {
     public mutating func sortByName() {
         self.sort { $0.settings.name.lowercased() < $1.settings.name.lowercased() }
+    }
+    public mutating func sortByActive() {
+        self.sort { $0.isActive && !$1.isActive }
     }
 }

--- a/WhiskyKit/Whisky/BottleData.swift
+++ b/WhiskyKit/Whisky/BottleData.swift
@@ -59,13 +59,14 @@ public struct BottleData: Codable {
                 .path(percentEncoded: false)
 
             if FileManager.default.fileExists(atPath: bottleMetadata) {
-                bottles.append(Bottle(bottleUrl: path))
+                bottles.append(Bottle(bottleUrl: path, isActive: true))
             } else {
-                paths.removeAll(where: { $0 == path })
+                bottles.append(Bottle(bottleUrl: path))
             }
         }
 
         bottles.sortByName()
+        bottles.sortByActive()
         return bottles
     }
 


### PR DESCRIPTION
This version of Whisky does not forget bottles, that are currently unavailable (existing on disconnected hard drive for example)
Instead it shows them as unavailable, and does not allow to interact with them (deleting them from app database is an possible)
When bottles get available again (hard drive plugged back for example) it is needed to hit the refresh button, and bottle state will be refreshed in the app

<img width="1012" alt="image" src="https://github.com/Whisky-App/Whisky/assets/51081713/642b990a-fa99-4575-991f-053ac0f41bf1">
<img width="895" alt="image" src="https://github.com/Whisky-App/Whisky/assets/51081713/4126e5b3-615b-4a90-85fd-7db8a0d81a2a">
