### PR TITLE
Update German Localizable.strings and fix DXVK translation

### DIFF
--- a/Whisky/de.lproj/Localizable.strings
+++ b/Whisky/de.lproj/Localizable.strings
@@ -42,7 +42,7 @@
 "config.dxvkHud.partial" = "Teilweise";
 "config.dxvkHud.fps" = "FPS";
 "config.dxvkHud.off" = "Aus";
-"config.dxvk.async" = "DXVK";
+"config.dxvk.async" = "DXVK Async";
 "config.dpi" = "DPI-Skalierung";
 "config.inspect" = "Konfigurieren...";
 


### PR DESCRIPTION
The "Async" word is missing in the german translation, that's why it display two switches in the UI with with the same label "DXVK". 

<img width="739" alt="image" src="https://github.com/Whisky-App/Whisky/assets/30625794/713112d6-7d7b-4715-9ebe-854a911e4d02">
