### PR TITLE
[Improvement] Async bottle loading

### DIFF
--- a/Whisky/Views/Bottle Views/BottleView.swift
+++ b/Whisky/Views/Bottle Views/BottleView.swift
@@ -41,17 +41,31 @@ struct BottleView: View {
     var body: some View {
         NavigationStack(path: $path) {
             ScrollView {
-                if pins.count > 0 {
-                    LazyVGrid(columns: gridLayout, alignment: .center) {
-                        ForEach(pins, id: \.url) { pin in
-                            PinnedProgramView(bottle: bottle,
-                                              pin: pin,
-                                              loadStartMenu: $loadStartMenu,
-                                              path: $path)
+                ZStack {
+                    if pins.count > 0 {
+                        LazyVGrid(columns: gridLayout, alignment: .center) {
+                            ForEach(pins, id: \.url) { pin in
+                                PinnedProgramView(bottle: bottle,
+                                                  pin: pin,
+                                                  loadStartMenu: $loadStartMenu,
+                                                  path: $path)
+                            }
+                        }
+                        .padding()
+                    }
+
+                    if isLoadingInstalledPrograms {
+                        HStack {
+                            Spacer()
+                            ProgressView()
+                                .padding()
+                                .background(Material.regular)
+                                .clipShape(RoundedRectangle(cornerSize: .init(width: 16, height: 16)))
+                            Spacer()
                         }
                     }
-                    .padding()
                 }
+
                 Form {
                     NavigationLink(value: BottleStage.programs) {
                         HStack {

--- a/Whisky/Views/Bottle Views/ProgramsView.swift
+++ b/Whisky/Views/Bottle Views/ProgramsView.swift
@@ -20,7 +20,7 @@ import SwiftUI
 import WhiskyKit
 
 struct ProgramsView: View {
-    let bottle: Bottle
+    @Binding var bottle: Bottle
     @State var programs: [Program] = []
     @State var blocklist: [URL] = []
     @State private var selectedPrograms = Set<Program>()

--- a/Whisky/Views/Bottle Views/ProgramsView.swift
+++ b/Whisky/Views/Bottle Views/ProgramsView.swift
@@ -68,26 +68,43 @@ struct ProgramsView: View {
         .animation(.easeInOut(duration: 0.2), value: isBlocklistExpanded)
         .navigationTitle("tab.programs")
         .onAppear {
-            programs = bottle.updateInstalledPrograms()
-            blocklist = bottle.settings.blocklist
-            sortPrograms()
+            loadPrograms()
         }
         .onChange(of: resortPrograms) {
+            sortPrograms()
             reloadStartMenu.toggle()
+        }
+    }
+
+    func loadPrograms() {
+        if bottle.programs.isEmpty {
+            updatePrograms()
+            return
+        }
+
+        programs = bottle.programs
+        blocklist = bottle.settings.blocklist
+        sortPrograms()
+    }
+
+    private func updatePrograms() {
+        DispatchQueue(label: "whisky.lock.queue").async {
             programs = bottle.updateInstalledPrograms()
             blocklist = bottle.settings.blocklist
             sortPrograms()
         }
     }
 
-    func sortPrograms() {
-        var favourites = programs.filter { $0.pinned }
-        var nonFavourites = programs.filter { !$0.pinned }
-        favourites = favourites.sorted { $0.name < $1.name }
-        nonFavourites = nonFavourites.sorted { $0.name < $1.name }
-        programs.removeAll()
-        programs.append(contentsOf: favourites)
-        programs.append(contentsOf: nonFavourites)
+    private func sortPrograms() {
+        DispatchQueue(label: "whisky.lock.queue").async {
+            var favourites = programs.filter { $0.pinned }
+            var nonFavourites = programs.filter { !$0.pinned }
+            favourites = favourites.sorted { $0.name < $1.name }
+            nonFavourites = nonFavourites.sorted { $0.name < $1.name }
+            programs.removeAll()
+            programs.append(contentsOf: favourites)
+            programs.append(contentsOf: nonFavourites)
+        }
     }
 }
 

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/Bottle.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/Bottle.swift
@@ -42,6 +42,8 @@ public class Bottle: Hashable, Identifiable {
         self.inFlight = inFlight
         self.isActive = isActive
     }
+
+    public let lock = NSLock()
 }
 
 extension Array where Element == Bottle {


### PR DESCRIPTION
### What?
This PR makes the methods responsible for loading and updating a bottle's program list run asynchronously. It also adds indicators in the Bottle and Program views to make the user aware there's a loading operation in progress.

### Why?
With relatively large bottles, loading the programs list can sometimes take a long while. Whisky used to do this synchronously, which in turn would lock the app until the operation finished, leading to degraded performance every time you switched bottles or changed pinned programs, as well as slow startup times.

### How?
By moving execution of methods that load a bottle's program list to a dedicated DispatchQueue and adding a lock to the Bottles struct to protect accesses as needed, since there's now a chance for concurrent load operations to happen. Besides that, calls to `updateInstalledPrograms()` have been reduced, and this method will only run if the programs list for the current bottle is empty. This means that pinning/unpinning programs in the programs list won't trigger a full reload, for instance.
UI affordances were implemented using common SwiftUI components.

![image](https://github.com/Whisky-App/Whisky/assets/13265148/270dbb06-a75b-42d1-af22-648f02440ac8)
![image](https://github.com/Whisky-App/Whisky/assets/13265148/c189cfb1-d893-45d9-a81b-059af3bd0660)
