### PR TITLE
Fix esync Setting

### DIFF
--- a/WhiskyKit/Sources/WhiskyKit/Whisky/BottleSettings.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/BottleSettings.swift
@@ -276,7 +276,7 @@ public struct BottleSettings: Codable {
         case .none:
             break
         case .esync:
-            wineEnv.updateValue("1", forKey: "WINEMSYNC")
+            wineEnv.updateValue("1", forKey: "WINEESYNC")
         case .msync:
             wineEnv.updateValue("1", forKey: "WINEMSYNC")
         }


### PR DESCRIPTION
Nice you added the esync option!
But it looks like you're setting `WINEMSYNC` instead of `WINEESYNC` when setting the esync option. I figured this is probably a mistake.

Also as just a Note: Could just use `wineEnv["WINEESYNC"] = 1` instead of the `updateValue` if you don't need to know the original value.