### PR TITLE
[Feat] Manual Pinned Programs

### DIFF
--- a/Whisky.xcodeproj/project.pbxproj
+++ b/Whisky.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		8CB681E52AED7C6F0018D319 /* WhiskyKit in Resources */ = {isa = PBXBuildFile; fileRef = 8CB681E42AED7C6F0018D319 /* WhiskyKit */; };
 		8CB681E72AED7CD00018D319 /* WhiskyKit in Frameworks */ = {isa = PBXBuildFile; productRef = 8CB681E62AED7CD00018D319 /* WhiskyKit */; };
 		AB66A8642A4195B10006D238 /* Rosetta2.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB66A8632A4195B10006D238 /* Rosetta2.swift */; };
+		DB696FC82AFAE5DA0037EB2F /* PinCreationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB696FC72AFAE5DA0037EB2F /* PinCreationView.swift */; };
 		EB58FB552A499896002DC184 /* SemanticVersion in Frameworks */ = {isa = PBXBuildFile; productRef = EB58FB542A499896002DC184 /* SemanticVersion */; };
 		EEA5A2462A31DD65008274AE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEA5A2452A31DD65008274AE /* AppDelegate.swift */; };
 /* End PBXBuildFile section */
@@ -151,6 +152,7 @@
 		8C73E1332AF472FC00B6FB45 /* ProgramMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgramMenuView.swift; sourceTree = "<group>"; };
 		8CB681E42AED7C6F0018D319 /* WhiskyKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = WhiskyKit; sourceTree = "<group>"; };
 		AB66A8632A4195B10006D238 /* Rosetta2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Rosetta2.swift; sourceTree = "<group>"; };
+		DB696FC72AFAE5DA0037EB2F /* PinCreationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinCreationView.swift; sourceTree = "<group>"; };
 		EEA5A2452A31DD65008274AE /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -203,6 +205,7 @@
 			children = (
 				6E17B6432AF3FD9600831173 /* PinRenameView.swift */,
 				6E17B6452AF3FDC100831173 /* PinsView.swift */,
+				DB696FC72AFAE5DA0037EB2F /* PinCreationView.swift */,
 			);
 			path = Pins;
 			sourceTree = "<group>";
@@ -569,6 +572,7 @@
 				6E50D98029CD0850008C39F6 /* Wine.swift in Sources */,
 				AB66A8642A4195B10006D238 /* Rosetta2.swift in Sources */,
 				6E355E5A29D782B2002D83BE /* ProgramsView.swift in Sources */,
+				DB696FC82AFAE5DA0037EB2F /* PinCreationView.swift in Sources */,
 				6E7C07BE2AAE7B0100F6E66B /* ProgramShortcut.swift in Sources */,
 				6E355E5829D78249002D83BE /* ConfigView.swift in Sources */,
 				6EA2D47E29DDAE5E00C84668 /* BottleRenameView.swift in Sources */,

--- a/Whisky/Localizable.xcstrings
+++ b/Whisky/Localizable.xcstrings
@@ -8508,16 +8508,6 @@
         }
       }
     },
-    "pin.createFirst" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pin your first program to get started"
-          }
-        }
-      }
-    },
     "pin.error.duplicate.%@" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Whisky/Localizable.xcstrings
+++ b/Whisky/Localizable.xcstrings
@@ -8518,7 +8518,8 @@
         }
       }
     },
-    "pin.error.duplicate" : {
+    "pin.error.duplicate.%@" : {
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {

--- a/Whisky/Localizable.xcstrings
+++ b/Whisky/Localizable.xcstrings
@@ -4072,7 +4072,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Rodzaj synchronizacji" 
+            "value" : "Rodzaj synchronizacji"
           }
         },
         "pl" : {
@@ -8494,6 +8494,86 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "設置..."
+          }
+        }
+      }
+    },
+    "pin.create" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pin"
+          }
+        }
+      }
+    },
+    "pin.createFirst" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pin your first program to get started"
+          }
+        }
+      }
+    },
+    "pin.error.duplicate" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "\"%@\" is already pinned!"
+          }
+        }
+      }
+    },
+    "pin.error.title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error Pinning Program"
+          }
+        }
+      }
+    },
+    "pin.help" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pin Program"
+          }
+        }
+      }
+    },
+    "pin.name" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pin name:"
+          }
+        }
+      }
+    },
+    "pin.path" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Program path:"
+          }
+        }
+      }
+    },
+    "pin.title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pin Program"
           }
         }
       }

--- a/Whisky/Models/Bottle.swift
+++ b/Whisky/Models/Bottle.swift
@@ -115,6 +115,16 @@ extension Bottle {
         // Apply blocklist
         programs = programs.filter { !settings.blocklist.contains($0.url) }
 
+        // Apply pinned list as programs, if not already included
+        settings.pins.forEach { pin in
+            if let pinnedUrl = pin.url {
+                let program = Program(name: pin.name, url: pinnedUrl, bottle: self)
+                if !programs.contains(program) {
+                    programs.append(program)
+                }
+            }
+        }
+
         programs.sort { $0.name.lowercased() < $1.name.lowercased() }
         return programs
     }

--- a/Whisky/Models/Bottle.swift
+++ b/Whisky/Models/Bottle.swift
@@ -110,16 +110,6 @@ extension Bottle {
             programs.append(Program(url: url, bottle: self))
         }
 
-        // Apply pinned list as programs, if not already included
-        settings.pins.forEach { pin in
-            if let pinnedUrl = pin.url {
-                let program = Program(url: pinnedUrl, bottle: self)
-                if !programs.contains(program) {
-                    programs.append(program)
-                }
-            }
-        }
-
         self.programs = programs.sorted { $0.name.lowercased() < $1.name.lowercased() }
     }
 

--- a/Whisky/Models/Bottle.swift
+++ b/Whisky/Models/Bottle.swift
@@ -113,7 +113,7 @@ extension Bottle {
         // Apply pinned list as programs, if not already included
         settings.pins.forEach { pin in
             if let pinnedUrl = pin.url {
-                let program = Program(name: pin.name, url: pinnedUrl, bottle: self)
+                let program = Program(url: pinnedUrl, bottle: self)
                 if !programs.contains(program) {
                     programs.append(program)
                 }

--- a/Whisky/Views/Bottle/BottleView.swift
+++ b/Whisky/Views/Bottle/BottleView.swift
@@ -30,6 +30,7 @@ struct BottleView: View {
     @State private var path = NavigationPath()
     @State var programLoading: Bool = false
     @State var showWinetricksSheet: Bool = false
+    @State var showPinCreation: Bool = false
 
     private let gridLayout = [GridItem(.adaptive(minimum: 100, maximum: .infinity))]
 
@@ -44,6 +45,22 @@ struct BottleView: View {
                                 bottle: bottle, pin: pin, path: $path
                             )
                         }
+                    }
+                    .padding()
+                } else {
+                    VStack {
+                        Text("pin.createFirst")
+                        Button {
+                            showPinCreation.toggle()
+                        } label: {
+                            HStack {
+                                Image(systemName: "pin")
+                                Text("pin.help")
+                            }
+                            .padding(6)
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .tint(.accentColor)
                     }
                     .padding()
                 }
@@ -125,6 +142,19 @@ struct BottleView: View {
             }
             .disabled(!bottle.isActive)
             .navigationTitle(bottle.settings.name)
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Button {
+                        showPinCreation.toggle()
+                    } label: {
+                        Image(systemName: "pin")
+                            .help("pin.help")
+                    }
+                }
+            }
+            .sheet(isPresented: $showPinCreation) {
+                PinCreationView(bottle: bottle)
+            }
             .sheet(isPresented: $showWinetricksSheet) {
                 WinetricksView(bottle: bottle)
             }

--- a/Whisky/Views/Bottle/BottleView.swift
+++ b/Whisky/Views/Bottle/BottleView.swift
@@ -38,9 +38,9 @@ struct BottleView: View {
         NavigationStack(path: $path) {
             ScrollView {
                 LazyVGrid(columns: gridLayout, alignment: .center) {
-                    ForEach(bottle.settings.pins, id: \.url) { pin in
+                    ForEach(bottle.pinnedPrograms, id: \.program.url) { pinnedProgram in
                         PinsView(
-                            bottle: bottle, pin: pin, path: $path
+                            bottle: bottle, program: pinnedProgram.program, pin: pinnedProgram.pin, path: $path
                         )
                     }
                     VStack {

--- a/Whisky/Views/Bottle/BottleView.swift
+++ b/Whisky/Views/Bottle/BottleView.swift
@@ -30,7 +30,6 @@ struct BottleView: View {
     @State private var path = NavigationPath()
     @State var programLoading: Bool = false
     @State var showWinetricksSheet: Bool = false
-    @State var showPinCreation: Bool = false
 
     private let gridLayout = [GridItem(.adaptive(minimum: 100, maximum: .infinity))]
 
@@ -43,27 +42,7 @@ struct BottleView: View {
                             bottle: bottle, program: pinnedProgram.program, pin: pinnedProgram.pin, path: $path
                         )
                     }
-                    VStack {
-                        Group {
-                            Image(systemName: "app.dashed")
-                                  .resizable()
-                                  .overlay {
-                                      Image(systemName: "plus")
-                                          .resizable()
-                                          .frame(width: 16, height: 16)
-                                  }
-                        }
-                        .frame(width: 45, height: 45)
-                        Spacer()
-                        Text("pin.help")
-                            .multilineTextAlignment(.center)
-                            .lineLimit(2, reservesSpace: true)
-                    }
-                    .frame(width: 90, height: 90)
-                    .padding(10)
-                    .onTapGesture(count: 1) {
-                        showPinCreation.toggle()
-                    }
+                    PinButtonView(bottle: bottle)
                 }
                 .padding()
                 Form {
@@ -144,9 +123,6 @@ struct BottleView: View {
             }
             .disabled(!bottle.isActive)
             .navigationTitle(bottle.settings.name)
-            .sheet(isPresented: $showPinCreation) {
-                PinCreationView(bottle: bottle)
-            }
             .sheet(isPresented: $showWinetricksSheet) {
                 WinetricksView(bottle: bottle)
             }

--- a/Whisky/Views/Bottle/BottleView.swift
+++ b/Whisky/Views/Bottle/BottleView.swift
@@ -37,33 +37,35 @@ struct BottleView: View {
     var body: some View {
         NavigationStack(path: $path) {
             ScrollView {
-                let pinnedPrograms = bottle.programs.pinned
-                if pinnedPrograms.count > 0 {
-                    LazyVGrid(columns: gridLayout, alignment: .center) {
-                        ForEach(bottle.settings.pins, id: \.url) { pin in
-                            PinsView(
-                                bottle: bottle, pin: pin, path: $path
-                            )
-                        }
+                LazyVGrid(columns: gridLayout, alignment: .center) {
+                    ForEach(bottle.settings.pins, id: \.url) { pin in
+                        PinsView(
+                            bottle: bottle, pin: pin, path: $path
+                        )
                     }
-                    .padding()
-                } else {
                     VStack {
-                        Text("pin.createFirst")
-                        Button {
-                            showPinCreation.toggle()
-                        } label: {
-                            HStack {
-                                Image(systemName: "pin")
-                                Text("pin.help")
-                            }
-                            .padding(6)
+                        Group {
+                            Image(systemName: "app.dashed")
+                                  .resizable()
+                                  .overlay {
+                                      Image(systemName: "plus")
+                                          .resizable()
+                                          .frame(width: 16, height: 16)
+                                  }
                         }
-                        .buttonStyle(.borderedProminent)
-                        .tint(.accentColor)
+                        .frame(width: 45, height: 45)
+                        Spacer()
+                        Text("pin.help")
+                            .multilineTextAlignment(.center)
+                            .lineLimit(2, reservesSpace: true)
                     }
-                    .padding()
+                    .frame(width: 90, height: 90)
+                    .padding(10)
+                    .onTapGesture(count: 1) {
+                        showPinCreation.toggle()
+                    }
                 }
+                .padding()
                 Form {
                     NavigationLink(value: BottleStage.programs) {
                         HStack {
@@ -142,16 +144,6 @@ struct BottleView: View {
             }
             .disabled(!bottle.isActive)
             .navigationTitle(bottle.settings.name)
-            .toolbar {
-                ToolbarItem(placement: .primaryAction) {
-                    Button {
-                        showPinCreation.toggle()
-                    } label: {
-                        Image(systemName: "pin")
-                            .help("pin.help")
-                    }
-                }
-            }
             .sheet(isPresented: $showPinCreation) {
                 PinCreationView(bottle: bottle)
             }

--- a/Whisky/Views/Bottle/BottleView.swift
+++ b/Whisky/Views/Bottle/BottleView.swift
@@ -38,7 +38,7 @@ struct BottleView: View {
         NavigationStack(path: $path) {
             ScrollView {
                 LazyVGrid(columns: gridLayout, alignment: .center) {
-                    ForEach(bottle.pinnedPrograms, id: \.program.url) { pinnedProgram in
+                    ForEach(bottle.pinnedPrograms, id: \.id) { pinnedProgram in
                         PinsView(
                             bottle: bottle, program: pinnedProgram.program, pin: pinnedProgram.pin, path: $path
                         )

--- a/Whisky/Views/Bottle/Pins/PinCreationView.swift
+++ b/Whisky/Views/Bottle/Pins/PinCreationView.swift
@@ -22,9 +22,8 @@ import WhiskyKit
 
 struct PinCreationView: View {
     let bottle: Bottle
+    @State var newPinURL: URL?
     @State private var newPinName: String = ""
-    @State private var newPinURL: URL?
-    @State private var isValid: Bool = false
     @State private var isDuplicate: Bool = false
     @Environment(\.dismiss) private var dismiss
 
@@ -53,17 +52,10 @@ struct PinCreationView: View {
                     panel.canChooseDirectories = false
                     panel.allowsMultipleSelection = false
                     panel.canCreateDirectories = false
-                    panel.begin { result in
-                        guard result == .OK, let url = panel.urls.first else { return }
-                        let oldDefaultName = (newPinURL ?? url).deletingPathExtension()
-                            .lastPathComponent
-                        newPinURL = url
-                        // Only reset newPinName if the textbox hasn't been modified
-                        if newPinName.isEmpty || newPinName == oldDefaultName {
-                            newPinName = url.deletingPathExtension()
-                                .lastPathComponent
-                        }
-                    }
+
+                    guard panel.runModal() == .OK,
+                          let url = panel.urls.first else { return }
+                    newPinURL = url
                 }
             }
             if let newPinURL {
@@ -104,7 +96,78 @@ struct PinCreationView: View {
                 }
             }
         }
+        .onChange(of: newPinURL, initial: true) { oldValue, newValue in
+            guard newValue != nil else { return }
+
+            // Only reset newPinName if the textbox hasn't been modified
+            if newPinName.isEmpty ||
+               newPinName == oldValue?.deletingPathExtension().lastPathComponent {
+
+                newPinName = newValue?.deletingPathExtension().lastPathComponent ?? ""
+            }
+        }
         .padding()
         .frame(width: 400)
+    }
+}
+
+struct PinButtonView: View {
+    let bottle: Bottle
+    @State private var newPinURL: URL?
+    @State private var opening: Bool = false
+    private let panel = NSOpenPanel()
+
+    var body: some View {
+        VStack {
+            Group {
+                Image(systemName: "app.dashed")
+                      .resizable()
+                      .overlay {
+                          Image(systemName: "plus")
+                              .resizable()
+                              .frame(width: 16, height: 16)
+                      }
+            }
+            .frame(width: 45, height: 45)
+            .scaleEffect(opening ? 2 : 1)
+            .opacity(opening ? 0 : 1)
+            Spacer()
+            Text("pin.help")
+                .multilineTextAlignment(.center)
+                .lineLimit(2, reservesSpace: true)
+        }
+        .frame(width: 90, height: 90)
+        .padding(10)
+        .onTapGesture(count: 1) {
+            panel.canChooseFiles = true
+            panel.allowedContentTypes = [UTType.exe,
+                                         UTType(exportedAs: "com.microsoft.msi-installer"),
+                                         UTType(exportedAs: "com.microsoft.bat")]
+            panel.directoryURL = bottle.url.appending(path: "drive_c")
+            panel.canChooseDirectories = false
+            panel.allowsMultipleSelection = false
+            panel.canCreateDirectories = false
+
+            choosePinURL()
+        }
+        .sheet(item: $newPinURL) { url in
+            PinCreationView(bottle: bottle, newPinURL: url)
+        }
+    }
+
+    func choosePinURL() {
+        withAnimation(.easeIn(duration: 0.25)) {
+            opening = true
+        } completion: {
+            withAnimation(.easeOut(duration: 0.1)) {
+                opening = false
+            }
+        }
+
+        Task {
+            guard await panel.runModal() == .OK,
+                  let url = await panel.urls.first else { return }
+            newPinURL = url
+        }
     }
 }

--- a/Whisky/Views/Bottle/Pins/PinCreationView.swift
+++ b/Whisky/Views/Bottle/Pins/PinCreationView.swift
@@ -81,27 +81,16 @@ struct PinCreationView: View {
                 Button("pin.create") {
                     guard let newPinURL else { return }
 
-                    let newPin = PinnedProgram(name: newPinName, url: newPinURL)
-
                     // Ensure this pin doesn't already exist
-                    guard !bottle.settings.pins.contains(where: { pin in
-                        pin.url == newPin.url
-                    }) else {
+                    guard !bottle.settings.pins.contains(where: { $0.url == newPinURL })
+                    else {
                         isDuplicate = true
                         return
                     }
 
-                    bottle.settings.pins.append(newPin)
-
-                    // Add this program to the programs array if necessary
-                    if !bottle.programs.contains(where: { program in
-                        program.url == newPin.url
-                    }) {
-                        bottle.programs.append(Program(url: newPinURL, bottle: bottle))
-                    }
+                    bottle.settings.pins.append(PinnedProgram(name: newPinName, url: newPinURL))
 
                     // Trigger a reload
-                    bottle.settings.pins = bottle.settings.pins
                     bottle.updateInstalledPrograms()
                     dismiss()
                 }

--- a/Whisky/Views/Bottle/Pins/PinCreationView.swift
+++ b/Whisky/Views/Bottle/Pins/PinCreationView.swift
@@ -81,7 +81,7 @@ struct PinCreationView: View {
                 Button("pin.create") {
                     guard let newPinURL else { return }
 
-                    let newlyCreatedPin = Program(name: newPinName, url: newPinURL, bottle: bottle)
+                    let newlyCreatedPin = Program(url: newPinURL, bottle: bottle)
                     let existingProgram = bottle.programs.first(where: { program in
                         program.url == newlyCreatedPin.url
                     })

--- a/Whisky/Views/Bottle/Pins/PinCreationView.swift
+++ b/Whisky/Views/Bottle/Pins/PinCreationView.swift
@@ -81,23 +81,29 @@ struct PinCreationView: View {
                 Button("pin.create") {
                     guard let newPinURL else { return }
 
-                    let newlyCreatedPin = Program(url: newPinURL, bottle: bottle)
-                    let existingProgram = bottle.programs.first(where: { program in
-                        program.url == newlyCreatedPin.url
-                    })
-                    // Ensure this URL isn't already pinned
-                    isDuplicate = existingProgram?.pinned ?? false
-                    if !isDuplicate {
-                        // If this is a new program, add it to the array
-                        if existingProgram != nil {
-                            bottle.programs.append(newlyCreatedPin)
-                        }
-                        newlyCreatedPin.pinned = true
-                        // Trigger a reload
-                        bottle.settings.pins = bottle.settings.pins
-                        bottle.updateInstalledPrograms()
-                        dismiss()
+                    let newPin = PinnedProgram(name: newPinName, url: newPinURL)
+
+                    // Ensure this pin doesn't already exist
+                    guard !bottle.settings.pins.contains(where: { pin in
+                        pin.url == newPin.url
+                    }) else {
+                        isDuplicate = true
+                        return
                     }
+
+                    bottle.settings.pins.append(newPin)
+
+                    // Add this program to the programs array if necessary
+                    if !bottle.programs.contains(where: { program in
+                        program.url == newPin.url
+                    }) {
+                        bottle.programs.append(Program(url: newPinURL, bottle: bottle))
+                    }
+
+                    // Trigger a reload
+                    bottle.settings.pins = bottle.settings.pins
+                    bottle.updateInstalledPrograms()
+                    dismiss()
                 }
                 .keyboardShortcut(.defaultAction)
                 .disabled(newPinName.isEmpty || newPinURL == nil)

--- a/Whisky/Views/Bottle/Pins/PinCreationView.swift
+++ b/Whisky/Views/Bottle/Pins/PinCreationView.swift
@@ -1,0 +1,134 @@
+//
+//  PinCreationView.swift
+//  Whisky
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import SwiftUI
+import UniformTypeIdentifiers
+import WhiskyKit
+
+struct PinCreationView: View {
+    var bottle: Bottle
+    @State var newPinName: String = ""
+    @State var newPinURL: URL = BottleData.defaultBottleDir
+    @State var pinPath: String = ""
+    @State var nameValid: Bool = false
+    @State var didError: Bool = false
+    @State var errorMessage: String = ""
+    @Environment(\.dismiss) var dismiss
+
+    var body: some View {
+        VStack {
+            HStack {
+                Text("pin.title")
+                    .bold()
+                Spacer()
+            }
+            Divider()
+            HStack(alignment: .top) {
+                Text("pin.name")
+                Spacer()
+                TextField(String(), text: $newPinName)
+                    .frame(width: 180)
+                    .textFieldStyle(.roundedBorder)
+                    .onChange(of: newPinName) { _, name in
+                        nameValid = !name.isEmpty
+                    }
+            }
+            HStack {
+                Text("pin.path")
+                Spacer()
+                Button("create.browse") {
+                    let panel = NSOpenPanel()
+                    panel.canChooseFiles = true
+                    panel.allowedContentTypes = [UTType.exe,
+                                                 UTType(exportedAs: "com.microsoft.msi-installer"),
+                                                 UTType(exportedAs: "com.microsoft.bat")]
+                    panel.directoryURL = bottle.url.appending(path: "drive_c")
+                    panel.canChooseDirectories = false
+                    panel.allowsMultipleSelection = false
+                    panel.canCreateDirectories = false
+                    panel.begin { result in
+                        if result == .OK {
+                            if let url = panel.urls.first {
+                                newPinURL = url
+                            }
+                        }
+                    }
+                }
+            }
+            HStack {
+                Text(pinPath)
+                    .truncationMode(.middle)
+                    .lineLimit(2)
+                    .help(pinPath)
+            }
+            Spacer()
+            HStack {
+                Spacer()
+                Button("create.cancel") {
+                    dismiss()
+                }
+                .keyboardShortcut(.cancelAction)
+                Button("pin.create") {
+                    let newlyCreatedPin = Program(name: newPinName, url: newPinURL, bottle: bottle)
+                    let existingProgram = bottle.programs.first(where: { program in
+                        program.url == newlyCreatedPin.url
+                    })
+                    // Ensure this URL isn't already pinned
+                    errorMessage = String(format: String(localized: "pin.error.duplicate"),
+                                          newPinURL.lastPathComponent)
+                    didError = existingProgram != nil && existingProgram?.pinned ?? false
+                    if !didError {
+                        // If this is a new program, add it to the array
+                        if existingProgram != nil {
+                            bottle.programs.append(newlyCreatedPin)
+                        }
+                        newlyCreatedPin.pinned = true
+                        // Trigger a reload
+                        bottle.settings.pins = bottle.settings.pins
+                        bottle.updateInstalledPrograms()
+                        dismiss()
+                    }
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(!nameValid)
+                .alert(String(localized: "pin.error.title"),
+                    isPresented: $didError
+                ) {
+                    Button("button.ok") {
+                    }
+                } message: {
+                    Text(errorMessage)
+                }
+            }
+        }
+        .padding()
+        .onChange(of: newPinURL) {
+            pinPath = newPinURL.prettyPath()
+            if newPinName.isEmpty {
+                newPinName = newPinURL.lastPathComponent
+                                        .replacingOccurrences(of: ".exe", with: "")
+            }
+        }
+        .onAppear {
+            pinPath = bottle.url
+                .appending(path: "drive_c")
+                .prettyPath()
+        }
+        .frame(width: 400, height: 180)
+    }
+}

--- a/Whisky/Views/Bottle/Pins/PinCreationView.swift
+++ b/Whisky/Views/Bottle/Pins/PinCreationView.swift
@@ -55,14 +55,13 @@ struct PinCreationView: View {
                     panel.canCreateDirectories = false
                     panel.begin { result in
                         guard result == .OK, let url = panel.urls.first else { return }
-                        let pattern = "\\.(exe|msi|bat)$"
-                        let oldDefaultName = (newPinURL ?? url).lastPathComponent
-                            .replacingOccurrences(of: pattern, with: "", options: .regularExpression)
+                        let oldDefaultName = (newPinURL ?? url).deletingPathExtension()
+                            .lastPathComponent
                         newPinURL = url
                         // Only reset newPinName if the textbox hasn't been modified
                         if newPinName.isEmpty || newPinName == oldDefaultName {
-                            newPinName = url.lastPathComponent
-                                .replacingOccurrences(of: pattern, with: "", options: .regularExpression)
+                            newPinName = url.deletingPathExtension()
+                                .lastPathComponent
                         }
                     }
                 }
@@ -87,7 +86,7 @@ struct PinCreationView: View {
                         program.url == newlyCreatedPin.url
                     })
                     // Ensure this URL isn't already pinned
-                    isDuplicate = existingProgram != nil && existingProgram?.pinned ?? false
+                    isDuplicate = existingProgram?.pinned ?? false
                     if !isDuplicate {
                         // If this is a new program, add it to the array
                         if existingProgram != nil {
@@ -101,7 +100,7 @@ struct PinCreationView: View {
                     }
                 }
                 .keyboardShortcut(.defaultAction)
-                .disabled(newPinName.isEmpty || newPinURL == bottle.url.appending(path: "drive_c"))
+                .disabled(newPinName.isEmpty || newPinURL == nil)
                 .alert("pin.error.title",
                     isPresented: $isDuplicate
                 ) {}

--- a/Whisky/Views/Bottle/Pins/PinsView.swift
+++ b/Whisky/Views/Bottle/Pins/PinsView.swift
@@ -45,9 +45,9 @@ struct PinsView: View {
             .scaleEffect(opening ? 2 : 1)
             .opacity(opening ? 0 : 1)
             Spacer()
-            Text(name + "\n")
+            Text(name)
                 .multilineTextAlignment(.center)
-                .lineLimit(2)
+                .lineLimit(2, reservesSpace: true)
         }
         .frame(width: 90, height: 90)
         .padding(10)

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/Bottle.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/Bottle.swift
@@ -42,10 +42,11 @@ public class Bottle: Hashable, Identifiable, ObservableObject {
     public var isActive: Bool = false
 
     /// All pins with their associated programs
-    public var pinnedPrograms: [(pin: PinnedProgram, program: Program)] {
+    public var pinnedPrograms: [(pin: PinnedProgram, program: Program, // swiftlint:disable:this large_tuple
+                                 id: String)] {
         return settings.pins.compactMap { pin in
             guard let program = programs.first(where: { $0.url == pin.url }) else { return nil }
-            return (pin, program)
+            return (pin, program, "\(pin.name)//\(program.url)")
         }
     }
 


### PR DESCRIPTION
Adds UI elements for manually pinning programs, useful for built-in Windows utilities, portable applications, applications that are not installed within the `Program Files` or `Program Files (x86)` directories, applications that don't create Start Menu shortcuts, etc.

Fixes #405 

In the main Bottle view:
* Toolbar button to pin a program
* Call to action and prominent `Pin Program` button when the pinned programs list is empty
<img width="1012" alt="Screenshot 2023-11-07 at 7 39 01 PM" src="https://github.com/Whisky-App/Whisky/assets/60248569/10e89248-1473-464d-87fd-730dbb30c527">

<details><summary>Manual Pinning UI and Result Examples</summary>
<p>
<img width="1012" alt="Screenshot 2023-11-07 at 7 39 34 PM" src="https://github.com/Whisky-App/Whisky/assets/60248569/af593757-c9a4-4923-9828-234903a0e889">
<img width="1012" alt="Screenshot 2023-11-07 at 7 39 43 PM" src="https://github.com/Whisky-App/Whisky/assets/60248569/b010f230-798b-4196-aa71-33093896f838">
</p>
</details> 

<details><summary>Pinned programs are intelligently added to the Installed Programs list for configuration parity.</summary>
<p>
<img width="1012" alt="Screenshot 2023-11-07 at 7 39 52 PM" src="https://github.com/Whisky-App/Whisky/assets/60248569/e8c790ab-5e19-4a25-9b2a-99ba6cba80f6">
</p>
</details> 

<details><summary>Attempts to pin the same program multiple times are detected and disallowed.</summary>
<p>
<img width="1012" alt="Screenshot 2023-11-07 at 7 40 41 PM" src="https://github.com/Whisky-App/Whisky/assets/60248569/2258b1c7-3e54-434a-9d79-73f16fca8788">
</p>
</details> 
