### PR TITLE
Some program loading cleanup

### DIFF
--- a/Whisky/Views/Bottle/BottleView.swift
+++ b/Whisky/Views/Bottle/BottleView.swift
@@ -36,12 +36,12 @@ struct BottleView: View {
     var body: some View {
         NavigationStack(path: $path) {
             ScrollView {
-                let pinnedPrograms = bottle.programs.pinned
+                let pinnedPrograms = bottle.pinnedPrograms
                 if pinnedPrograms.count > 0 {
                     LazyVGrid(columns: gridLayout, alignment: .center) {
-                        ForEach(bottle.settings.pins, id: \.url) { pin in
+                        ForEach(pinnedPrograms, id: \.program.url) { pinnedProgram in
                             PinsView(
-                                bottle: bottle, pin: pin, path: $path
+                                bottle: bottle, program: pinnedProgram.program, pin: pinnedProgram.pin, path: $path
                             )
                         }
                     }
@@ -150,18 +150,19 @@ struct BottleView: View {
     }
 
     private func updateStartMenu() {
-        bottle.programs = bottle.updateInstalledPrograms()
+        bottle.updateInstalledPrograms()
+
         let startMenuPrograms = bottle.getStartMenuPrograms()
         for startMenuProgram in startMenuPrograms {
             for program in bottle.programs where
             // For some godforsaken reason "foo/bar" != "foo/Bar" so...
             program.url.path().caseInsensitiveCompare(startMenuProgram.url.path()) == .orderedSame {
                 program.pinned = true
-                if !bottle.settings.pins.contains(where: { $0.url == program.url }) {
-                    bottle.settings.pins.append(PinnedProgram(name: program.name
-                                                                    .replacingOccurrences(of: ".exe", with: ""),
-                                                              url: program.url))
-                }
+                guard !bottle.settings.pins.contains(where: { $0.url == program.url }) else { return }
+                bottle.settings.pins.append(PinnedProgram(
+                    name: program.url.deletingPathExtension().lastPathComponent,
+                    url: program.url
+                ))
             }
         }
     }

--- a/Whisky/Views/Bottle/Pins/PinsView.swift
+++ b/Whisky/Views/Bottle/Pins/PinsView.swift
@@ -21,10 +21,10 @@ import WhiskyKit
 
 struct PinsView: View {
     @ObservedObject var bottle: Bottle
+    @ObservedObject var program: Program
     @State var pin: PinnedProgram
     @Binding var path: NavigationPath
 
-    @State private var program: Program?
     @State private var image: NSImage?
     @State private var showRenameSheet = false
     @State private var name: String = ""
@@ -63,13 +63,11 @@ struct PinsView: View {
             .padding(EdgeInsets(top: 0, leading: 0, bottom: 12, trailing: 0))
         }
         .contextMenu {
-            if let program = program {
-                ProgramMenuView(program: program, path: $path)
+            ProgramMenuView(program: program, path: $path)
 
-                Button("button.rename", systemImage: "pencil.line") {
-                    showRenameSheet.toggle()
-                }.labelStyle(.titleAndIcon)
-            }
+            Button("button.rename", systemImage: "pencil.line") {
+                showRenameSheet.toggle()
+            }.labelStyle(.titleAndIcon)
         }
         .onTapGesture(count: 2) {
             runProgram()
@@ -80,11 +78,8 @@ struct PinsView: View {
         .onAppear {
             name = pin.name
             Task.detached { @MainActor in
-                program = bottle.programs.first(where: { $0.url == pin.url })
-                if let program {
-                    if let peFile = program.peFile {
-                        image = peFile.bestIcon()
-                    }
+                if let peFile = program.peFile {
+                    image = peFile.bestIcon()
                 }
             }
         }
@@ -104,10 +99,8 @@ struct PinsView: View {
             }
         }
 
-        if let program {
-            Task {
-                await program.run()
-            }
+        Task {
+            await program.run()
         }
     }
 }

--- a/Whisky/Views/ContentView.swift
+++ b/Whisky/Views/ContentView.swift
@@ -101,6 +101,9 @@ struct ContentView: View {
             ToolbarItem(placement: .primaryAction) {
                 Button {
                     bottleVM.loadBottles()
+                    if let bottle = bottleVM.bottles.first(where: { $0.url == selected }) {
+                        bottle.updateInstalledPrograms()
+                    }
                     refresh.toggle()
                     withAnimation(.default) {
                         refreshAnimation = .degrees(360)

--- a/WhiskyKit/Sources/WhiskyKit/PE/ShellLink.swift
+++ b/WhiskyKit/Sources/WhiskyKit/PE/ShellLink.swift
@@ -109,7 +109,7 @@ public struct LinkInfo: Hashable {
                         string.replace("\\", with: "/")
                         string.replace("C:", with: "\(bottle.url.path)/drive_c")
                         let url = URL(filePath: string)
-                        return Program(name: url.lastPathComponent, url: url, bottle: bottle)
+                        return Program(url: url, bottle: bottle)
                     }
                 }
             }

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/Program.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/Program.swift
@@ -29,10 +29,13 @@ public class Program: Hashable, ObservableObject {
         return hasher.combine(url)
     }
 
-    public let name: String
     public let bottle: Bottle
     public let url: URL
     public let settingsURL: URL
+
+    public var name: String {
+        url.lastPathComponent
+    }
 
     @Published public var settings: ProgramSettings {
         didSet { saveSettings() }
@@ -53,8 +56,8 @@ public class Program: Hashable, ObservableObject {
 
     public var peFile: PEFile?
 
-    public init(name: String, url: URL, bottle: Bottle) {
-        self.name = name
+    public init(url: URL, bottle: Bottle) {
+        let name = url.lastPathComponent
         self.bottle = bottle
         self.url = url
         self.pinned = bottle.settings.pins.contains(where: { $0.url == url })


### PR DESCRIPTION
Just some program maintenance
1. Remove pins for programs that are deleted so they don't necessarily float around
2. Make `PinsView` require a program so you don't end up with empty items
3. Fix missing pins after reloading bottles
4. Overall cleanup of code

Maybe we don't want to do 1. I see a potential of adding back a deleted program and the pin is restored. Could be a useful quality of life feature.

Also, i'm not sure I understand the concept of the blocklist. It seems sort of broken right now. On launching it filters out programs but doesn't do that when you actually block a program (could be my mistake). But even if we fixed that I'm not sure what the point of the feature is.