### PR TITLE
Update UI: BottleCreationView & PinCreationView

### DIFF
--- a/Whisky/Views/Bottle/BottleCreationView.swift
+++ b/Whisky/Views/Bottle/BottleCreationView.swift
@@ -20,90 +20,89 @@ import SwiftUI
 import WhiskyKit
 
 struct BottleCreationView: View {
-    @State var newBottleName: String = ""
-    @State var newBottleVersion: WinVersion = .win10
-    @State var newBottleURL: URL = BottleData.defaultBottleDir
-    @State var bottlePath: String = ""
-    @State var nameValid: Bool = false
     @Binding var newlyCreatedBottleURL: URL?
-    @Environment(\.dismiss) var dismiss
+
+    @State private var newBottleName: String = ""
+    @State private var newBottleVersion: WinVersion = .win10
+    @State private var newBottleURL: URL = BottleData.defaultBottleDir
+    @State private var bottlePath: String = ""
+    @State private var nameValid: Bool = false
+
+    @Environment(\.dismiss) private var dismiss
 
     var body: some View {
-        VStack {
-            HStack {
-                Text("create.title")
-                    .bold()
-                Spacer()
-            }
-            Divider()
-            HStack(alignment: .top) {
-                Text("create.name")
-                Spacer()
-                TextField(String(), text: $newBottleName)
-                    .frame(width: 180)
+        NavigationStack {
+            Form {
+                TextField("create.name", text: $newBottleName)
                     .onChange(of: newBottleName) { _, name in
                         nameValid = !name.isEmpty
                     }
-            }
-            HStack {
-                Text("create.win")
-                Spacer()
-                Picker(String(), selection: $newBottleVersion) {
+
+                Picker("create.win", selection: $newBottleVersion) {
                     ForEach(WinVersion.allCases.reversed(), id: \.self) {
                         Text($0.pretty())
                     }
                 }
-                .labelsHidden()
-                .frame(width: 180)
-            }
-            HStack {
-                Text("create.path")
-                Spacer()
-                Text(bottlePath)
-                    .truncationMode(.middle)
-                    .lineLimit(2)
-                    .help(bottlePath)
-                Button("create.browse") {
-                    let panel = NSOpenPanel()
-                    panel.canChooseFiles = false
-                    panel.canChooseDirectories = true
-                    panel.allowsMultipleSelection = false
-                    panel.canCreateDirectories = true
-                    panel.directoryURL = BottleData.containerDir
-                    panel.begin { result in
-                        if result == .OK {
-                            if let url = panel.urls.first {
-                                newBottleURL = url
+
+                HStack {
+                    VStack(alignment: .leading) {
+                        Text("create.path")
+                            .foregroundStyle(.primary)
+                        Text(bottlePath)
+                            .foregroundStyle(.secondary)
+                            .truncationMode(.middle)
+                            .lineLimit(2)
+                            .help(bottlePath)
+                    }
+
+                    Spacer()
+                    Button {
+                        let panel = NSOpenPanel()
+                        panel.canChooseFiles = false
+                        panel.canChooseDirectories = true
+                        panel.allowsMultipleSelection = false
+                        panel.canCreateDirectories = true
+                        panel.directoryURL = BottleData.containerDir
+                        panel.begin { result in
+                            if result == .OK {
+                                if let url = panel.urls.first {
+                                    newBottleURL = url
+                                }
                             }
                         }
+                    } label: {
+                        Text("create.browse")
                     }
                 }
             }
-            Spacer()
-            HStack {
-                Spacer()
-                Button("create.cancel") {
-                    dismiss()
+            .formStyle(.grouped)
+            .navigationTitle("create.title")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("create.cancel") {
+                        dismiss()
+                    }
+                    .keyboardShortcut(.cancelAction)
                 }
-                .keyboardShortcut(.cancelAction)
-                Button("create.create") {
-                    newlyCreatedBottleURL = BottleVM.shared.createNewBottle(bottleName: newBottleName,
-                                                    winVersion: newBottleVersion,
-                                                    bottleURL: newBottleURL)
-                    dismiss()
+                ToolbarItem(placement: .primaryAction) {
+                    Button("create.create") {
+                        newlyCreatedBottleURL = BottleVM.shared.createNewBottle(bottleName: newBottleName,
+                                                                                winVersion: newBottleVersion,
+                                                                                bottleURL: newBottleURL)
+                        dismiss()
+                    }
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(!nameValid)
                 }
-                .keyboardShortcut(.defaultAction)
-                .disabled(!nameValid)
+            }
+            .onChange(of: newBottleURL) {
+                bottlePath = newBottleURL.prettyPath()
+            }
+            .onAppear {
+                bottlePath = newBottleURL.prettyPath()
             }
         }
-        .padding()
-        .onChange(of: newBottleURL) {
-            bottlePath = newBottleURL.prettyPath()
-        }
-        .onAppear {
-            bottlePath = newBottleURL.prettyPath()
-        }
-        .frame(width: 400, height: 180)
+        .frame(minWidth: 400, minHeight: 210)
     }
 }
 

--- a/Whisky/Views/Bottle/WinetricksView.swift
+++ b/Whisky/Views/Bottle/WinetricksView.swift
@@ -47,25 +47,28 @@ struct WinetricksView: View {
                         }
                     }
                 }
-                HStack {
-                    Spacer()
-                    Button("create.cancel") {
-                        dismiss()
-                    }
-                    Button("button.run") {
-                        guard let selectedTrick = selectedTrick else {
-                            return
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("create.cancel") {
+                            dismiss()
                         }
-
-                        let trick = winetricks.flatMap { $0.verbs }.first(where: { $0.id == selectedTrick })
-                        if let trickName = trick?.name {
-                            Task.detached {
-                                await Winetricks.runCommand(command: trickName, bottle: bottle)
+                    }
+                    ToolbarItem(placement: .primaryAction) {
+                        Button("button.run") {
+                            guard let selectedTrick = selectedTrick else {
+                                return
                             }
+
+                            let trick = winetricks.flatMap { $0.verbs }.first(where: { $0.id == selectedTrick })
+                            if let trickName = trick?.name {
+                                Task.detached {
+                                    await Winetricks.runCommand(command: trickName, bottle: bottle)
+                                }
+                            }
+                            dismiss()
                         }
-                        dismiss()
+                        .buttonStyle(.borderedProminent)
                     }
-                    .buttonStyle(.borderedProminent)
                 }
             } else {
                 Spacer()


### PR DESCRIPTION
## Summary

Refactors `BottleCreationView` & `PinCreationView` to use `Form`, `toolbar` and `navigationTitle` instead of wrapped `VStack`s. Should look a bit cleaner and more consistent with general macOS UI and allow easier additions to the views in the future.

## Preview

New Bottle

<img width="740" alt="New Bottle" src="https://github.com/Whisky-App/Whisky/assets/6899256/a2416854-ba68-47c9-a61e-c1fe304360d2">

Pin Program

<img width="838" alt="Pin Program" src="https://github.com/Whisky-App/Whisky/assets/6899256/61cddfb7-7730-4936-91ed-533a5de8940d">
