### PR TITLE
Fix opening through document type

### DIFF
--- a/Whisky/AppDelegate.swift
+++ b/Whisky/AppDelegate.swift
@@ -24,8 +24,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func application(_ application: NSApplication, open urls: [URL]) {
         // Test if automatic window tabbing is enabled
-        // as it is disabled when ContentView appears.
-        // Prevents crashing
+        // as it is disabled when ContentView appears
         if NSWindow.allowsAutomaticWindowTabbing, let url = urls.first {
             // Reopen the file after Whisky has been opened
             // so that the `onOpenURL` handler is actually called

--- a/Whisky/AppDelegate.swift
+++ b/Whisky/AppDelegate.swift
@@ -22,6 +22,17 @@ import SwiftUI
 class AppDelegate: NSObject, NSApplicationDelegate {
     @AppStorage("hasShownMoveToApplicationsAlert") private var hasShownMoveToApplicationsAlert = false
 
+    func application(_ application: NSApplication, open urls: [URL]) {
+        // Test if automatic window tabbing is enabled
+        // as it is disabled when ContentView appears.
+        // Prevents crashing
+        if NSWindow.allowsAutomaticWindowTabbing, let url = urls.first {
+            // Reopen the file after Whisky has been opened
+            // so that the `onOpenURL` handler is actually called
+            NSWorkspace.shared.open(url)
+        }
+    }
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         if !hasShownMoveToApplicationsAlert && !AppDelegate.insideAppsFolder {
             DispatchQueue.main.asyncAfter(deadline: .now()) {

--- a/Whisky/Views/FileOpenView.swift
+++ b/Whisky/Views/FileOpenView.swift
@@ -57,12 +57,14 @@ struct FileOpenView: View {
         }
         .frame(minWidth: 400, minHeight: 115)
         .onAppear {
-            selection = bottles.first(where: { $0.url == currentBottle })?.url ?? bottles[0].url
-
             if bottles.count <= 1 {
                 // If the user only has one bottle
                 // there's nothing for them to select
                 run()
+            } else if bottles.count > 0 {
+                // Makes sure there are more than 0 bottles.
+                // Otherwise, it will crash on the nil cascade
+                selection = bottles.first(where: { $0.url == currentBottle })?.url ?? bottles[0].url
             }
         }
     }


### PR DESCRIPTION
Fixes bug where opening a file that launches Whisky does not call the `onOpenURL` handler, thus not showing the `FileOpenView` sheet.

Also fixes another bug where Whisky will crash due to bottles loading slower than `FileOpenView` appearing.