### PR TITLE
Add a setting to allow users to change the bottle's locale.

### DIFF
--- a/Whisky/Localizable.xcstrings
+++ b/Whisky/Localizable.xcstrings
@@ -4463,6 +4463,16 @@
         }
       }
     },
+    "config.locale" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Locale"
+          }
+        }
+      }
+    },
     "config.metalHud" : {
       "localizations" : {
         "da" : {
@@ -7802,6 +7812,9 @@
           }
         }
       }
+    },
+    "Key" : {
+      "extractionState" : "manual"
     },
     "kill.bottles" : {
       "localizations" : {

--- a/Whisky/Views/Bottle/ConfigView.swift
+++ b/Whisky/Views/Bottle/ConfigView.swift
@@ -35,6 +35,7 @@ struct ConfigView: View {
     @State private var buildVersionLoadingState: LoadingState = .loading
     @State private var retinaModeLoadingState: LoadingState = .loading
     @State private var dpiConfigLoadingState: LoadingState = .loading
+    @State private var localeLoadingState: LoadingState = .loading
     @State private var dpiSheetPresented: Bool = false
     @AppStorage("wineSectionExpanded") private var wineSectionExpanded: Bool = true
     @AppStorage("dxvkSectionExpanded") private var dxvkSectionExpanded: Bool = true
@@ -97,6 +98,13 @@ struct ConfigView: View {
                             isRetinaMode: $retinaMode,
                             presented: $dpiSheetPresented
                         )
+                    }
+                }
+                SettingItemView(title: "config.locale", loadingState: localeLoadingState) {
+                    Picker("config.locale", selection: $bottle.settings.locale) {
+                        ForEach(getSystemLocales(), id: \.self) {
+                            Text($0)
+                        }
                     }
                 }
             }
@@ -166,6 +174,7 @@ struct ConfigView: View {
         .navigationTitle("tab.config")
         .onAppear {
             winVersionLoadingState = .success
+            localeLoadingState = .success
 
             loadBuildName()
 


### PR DESCRIPTION
I couldn't find a way of passing LANG="" or LC_ALL="" to Whisky / the underlying wine binaries so this change will allow users to select one from a dropdown in Bottle Configuration.

The locales are found in /usr/share/locale and honestly I'm not sure if only the UTF-8 ones are required. What I do know, is that when setting LC_ALL to ja_JP.UTF-8, Japanese software will load with the correct fonts as long as CJKFonts is installed using WineTricks.

I apologise if the code isn't very good - This is my first time working with Swift.

Here are some screenshots:

# Before
<img width="814" alt="en_US Locale" src="https://github.com/Whisky-App/Whisky/assets/138996957/9d1b8099-aee4-4e7e-ad8c-6ff9fe5c8669">

# After 
<img width="765" alt="ja_JP Locale" src="https://github.com/Whisky-App/Whisky/assets/138996957/9a9b8790-f658-4369-8d2e-73668109bf2a">

# Settings
<img width="877" alt="English Bottle" src="https://github.com/Whisky-App/Whisky/assets/138996957/3b70ad85-12ea-40f2-9017-4b7c08d20401">
<img width="887" alt="Japanese Bottle" src="https://github.com/Whisky-App/Whisky/assets/138996957/3b9e2db1-6cb3-4aa9-b464-ac9f389128fd">
