### PR TITLE
Bottle Terminal button

### DIFF
--- a/Whisky/Localizable.xcstrings
+++ b/Whisky/Localizable.xcstrings
@@ -2327,6 +2327,17 @@
         }
       }
     },
+    "button.terminal" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminal"
+          }
+        }
+      }
+    },
     "button.unpin" : {
       "localizations" : {
         "da" : {

--- a/Whisky/Views/Bottle/BottleView.swift
+++ b/Whisky/Views/Bottle/BottleView.swift
@@ -66,6 +66,9 @@ struct BottleView: View {
                     Button("button.cDrive") {
                         bottle.openCDrive()
                     }
+                    Button("button.terminal") {
+                        bottle.openTerminal()
+                    }
                     Button("button.winetricks") {
                         showWinetricksSheet.toggle()
                     }

--- a/Whisky/Views/FileOpenView.swift
+++ b/Whisky/Views/FileOpenView.swift
@@ -57,14 +57,19 @@ struct FileOpenView: View {
         }
         .frame(minWidth: 400, minHeight: 115)
         .onAppear {
-            if bottles.count <= 1 {
+            // Makes sure there are more than 0 bottles.
+            // Otherwise, it will crash on the nil cascade
+            if bottles.count <= 0 {
+                dismiss()
+                return
+            }
+
+            selection = bottles.first(where: { $0.url == currentBottle })?.url ?? bottles[0].url
+
+            if bottles.count == 1 {
                 // If the user only has one bottle
                 // there's nothing for them to select
                 run()
-            } else if bottles.count > 0 {
-                // Makes sure there are more than 0 bottles.
-                // Otherwise, it will crash on the nil cascade
-                selection = bottles.first(where: { $0.url == currentBottle })?.url ?? bottles[0].url
             }
         }
     }

--- a/WhiskyCmd/Main.swift
+++ b/WhiskyCmd/Main.swift
@@ -33,7 +33,8 @@ struct Whisky: ParsableCommand {
 //                      Export.self,
                       Delete.self,
                       Remove.self,
-                      Run.self
+                      Run.self,
+                      Shellenv.self
                       /*Install.self,
                       Uninstall.self*/])
 }
@@ -132,7 +133,7 @@ extension Whisky {
                     print(error)
                 }
             } else {
-                print("No bottle called \"\(name)\" found.")
+                fputs("No bottle called \"\(name)\" found.\n", stderr)
             }
         }
     }
@@ -152,7 +153,7 @@ extension Whisky {
                 bottlesList.paths.removeAll(where: { $0 == bottleToRemove.url })
                 print("Removed \"\(name)\".")
             } else {
-                print("No bottle called \"\(name)\" found.")
+                fputs("No bottle called \"\(name)\" found.\n", stderr)
             }
         }
     }
@@ -169,13 +170,33 @@ extension Whisky {
             let bottles = bottlesList.loadBottles()
 
             guard let bottle = bottles.first(where: { $0.settings.name == bottleName }) else {
-                print("A bottle with that name doesn't exist.")
+                fputs("A bottle with that name doesn't exist.\n", stderr)
                 return
             }
 
             let url = URL(fileURLWithPath: path)
             let program = Program(url: url, bottle: bottle)
             program.runInTerminal()
+        }
+    }
+
+    struct Shellenv: ParsableCommand {
+        static var configuration = CommandConfiguration(abstract: "Prints export statements for a Bottle for eval.")
+
+        @Argument var bottleName: String
+
+        mutating func run() throws {
+            var bottlesList = BottleData()
+            let bottles = bottlesList.loadBottles()
+
+            guard let bottle = bottles.first(where: { $0.settings.name == bottleName }) else {
+                fputs("A bottle with that name doesn't exist.\n", stderr)
+                return
+            }
+
+            let envCmd = Wine.generateTerminalEnvironmentCommand(bottle: bottle)
+            print(envCmd)
+
         }
     }
 

--- a/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
@@ -115,10 +115,34 @@ public class Wine {
         var wineCmd = "\(wineBinary.esc) start /unix \(bottle.url.esc) \(args)"
         let env = constructWineEnvironment(for: bottle, environment: environment)
         for environment in env {
-            wineCmd = "\(environment.key)=\(environment.value) " + wineCmd
+            wineCmd = "\(environment.key)=\"\(environment.value)\" " + wineCmd
         }
 
         return wineCmd
+    }
+
+    public static func generateTerminalEnvironmentCommand(bottle: Bottle) -> String {
+        var cmd = """
+export PATH=\\\"\(GPTKInstaller.binFolder.path):$PATH\\\"
+export WINE=\\\"wine64\\\"
+alias wine=\\\"wine64\\\"
+alias winecfg=\\\"wine64 winecfg\\\"
+alias msiexec=\\\"wine64 msiexec\\\"
+alias regedit=\\\"wine64 regedit\\\"
+alias regsvr32=\\\"wine64 regsvr32\\\"
+alias wineboot=\\\"wine64 wineboot\\\"
+alias wineconsole=\\\"wine64 wineconsole\\\"
+alias winedbg=\\\"wine64 winedbg\\\"
+alias winefile=\\\"wine64 winefile\\\"
+alias winepath=\\\"wine64 winepath\\\"
+"""
+
+        let env = constructWineEnvironment(for: bottle, environment: constructWineEnvironment(for: bottle))
+        for environment in env {
+            cmd += "\nexport \(environment.key)=\\\"\(environment.value)\\\""
+        }
+
+        return cmd
     }
 
     /// Run a `wineserver` command with the given arguments and return the output result

--- a/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
@@ -123,23 +123,23 @@ public class Wine {
 
     public static func generateTerminalEnvironmentCommand(bottle: Bottle) -> String {
         var cmd = """
-export PATH=\\\"\(GPTKInstaller.binFolder.path):$PATH\\\"
-export WINE=\\\"wine64\\\"
-alias wine=\\\"wine64\\\"
-alias winecfg=\\\"wine64 winecfg\\\"
-alias msiexec=\\\"wine64 msiexec\\\"
-alias regedit=\\\"wine64 regedit\\\"
-alias regsvr32=\\\"wine64 regsvr32\\\"
-alias wineboot=\\\"wine64 wineboot\\\"
-alias wineconsole=\\\"wine64 wineconsole\\\"
-alias winedbg=\\\"wine64 winedbg\\\"
-alias winefile=\\\"wine64 winefile\\\"
-alias winepath=\\\"wine64 winepath\\\"
-"""
+        export PATH=\"\(GPTKInstaller.binFolder.path):$PATH\"
+        export WINE=\"wine64\"
+        alias wine=\"wine64\"
+        alias winecfg=\"wine64 winecfg\"
+        alias msiexec=\"wine64 msiexec\"
+        alias regedit=\"wine64 regedit\"
+        alias regsvr32=\"wine64 regsvr32\"
+        alias wineboot=\"wine64 wineboot\"
+        alias wineconsole=\"wine64 wineconsole\"
+        alias winedbg=\"wine64 winedbg\"
+        alias winefile=\"wine64 winefile\"
+        alias winepath=\"wine64 winepath\"
+        """
 
         let env = constructWineEnvironment(for: bottle, environment: constructWineEnvironment(for: bottle))
         for environment in env {
-            cmd += "\nexport \(environment.key)=\\\"\(environment.value)\\\""
+            cmd += "\nexport \(environment.key)=\"\(environment.value)\""
         }
 
         return cmd


### PR DESCRIPTION
Adds a button that opens a Terminal window with the correct environment variables and aliases for the current bottle.

It works by using an AppleScript to open a shell with ``eval "$(whisky shellenv "<bottle>")"`` (which can also be used on its own if Whisky CLI is installed).