### PR TITLE
feat: add the ability to change wiki content using files

### DIFF
--- a/.github/workflows/Wiki.yml
+++ b/.github/workflows/Wiki.yml
@@ -1,0 +1,29 @@
+name: Wiki
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - wiki/**
+
+env:
+  REPOSITORY_URL: https://${{ secrets.WIKI_TOKEN }}@github.com/${{ github.repository }}.wiki
+
+jobs:
+  Wiki:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Sync
+        run: |
+          mkdir _wiki
+          cd _wiki
+          git init
+          git config user.email ${{ github.actor }}@users.noreply.github.com
+          git config user.name ${{ github.actor }}
+          git pull $REPOSITORY_URL
+          rsync -av --delete ../wiki/ ../_wiki/ --exclude .git
+          git add .
+          git commit --allow-empty-message -m "${{ github.event.head_commit.message }}"
+          git push -f -u $REPOSITORY_URL master

--- a/wiki/A-Hitchhiker's-Guide-to-Whisky.md
+++ b/wiki/A-Hitchhiker's-Guide-to-Whisky.md
@@ -1,0 +1,85 @@
+## Welcome to Whisky
+
+We're glad you're here. Here's how to get up and running in a breeze.
+
+1. Download Whisky
+    - Download the latest release [here](https://github.com/IsaacMarovitz/Whisky/releases)
+2. Move Whisky to your Applications folder
+3. Open Whisky
+4. Follow on-screen instructions
+
+**Everything is now installed!**
+
+## Making your first bottle
+
+Bottles are the bread and butter of Wine. Bottles are like little Windows filesystems, and they appear on your computer as a normal folder. In a bottle, you'll find programs, registry files, and everything else you need to install and configure your Windows 'machine'. Each bottle is self-contained and will only have the programs you installed in that bottle.
+
+1. Press the plus button in the top right-hand corner
+2. Give your bottle a name, and select the Windows version you want
+3. Hit `Create` and wait a few seconds. When your bottle is ready, it'll appear in the list on the left-hand side
+
+## Installing your first program
+
+Programs are installed much like you would on a regular Windows machine.
+
+1. Download the program you want to run. It should be the *Windows* version (`.exe` or `.msi`); 64-bit programs are preferable
+2. Click on the bottle you want to install your program into
+3. Press the `Run...` button in the bottom right
+4. Navigate to where you downloaded your `.exe` or `.msi` file in Finder
+5. Select the file and press `Open`
+
+Whisky will then open and run the program. It may take a few seconds for the window to appear, so be patient.
+
+## Configuring your bottle
+
+In the `Config` menu of your bottle, you can adjust a number of parameters, including the Windows version and build the number of your bottle, enable and disable the Metal HUD, configure ESync, and open Wine's many configuration tools like the Control Panel, Registry Editor, and Wine Configuration dialogues.
+
+## When should I make a new bottle?
+
+The usual convention is to limit a bottle to one game, as dependencies and such can get messy with more installed in one place. If a game requires more extensive configuration to get working, it's usually a good idea to keep it contained. Overal, trust your judgment and separate where it feels right.
+
+---
+
+## Resolving common issues
+
+Several things can lead to a program not working. The most common reasons are listed below.
+
+|Problem|Solution|
+|-------|---------|
+|My game crashes due to "invalid instruction".|Your game is likely using [AVX](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions) instructions. These are more common in console ports. AVX instructions are x86 specific, and Rosetta doesn't translate them. Unless you can find a way to disable or bypass them (check online), then your game won't work.|
+|I want to play a competitive multiplayer game, but it won't load.|Competitive multiplayer games, especially battle royales and other FPS games (like PUBG, Fortnite, Apex Legends, Valorant), often have some form of driver-level anti-cheat. These won't work under Wine.|
+|My DirectX 9 game has graphical issues, or doesn't work at all.|DirectX 9 games are handled through Wine's own `wined3d`. Whisky focuses on modern titles using DX11 or 12, and you may run into issues with DX9 games. CrossOver is a better choice in this scenario, as it runs on Wine 8 instead of Wine 7, and has a more up-to-date version of `wined3d`. If you're not sure what Graphics API your game is using, you can check on the [PCGamingWiki](https://www.pcgamingwiki.com/wiki/Home).|
+|My game crashes out of the box, or complains about missing dependencies.|Make sure to check Wine's [AppDB](https://appdb.winehq.org/) and [ProtonDB](https://www.protondb.com/), which can often provide information on the necessary workarounds or Winetricks you need to use to get your game running. If you can't find anything or you are unable to make it work, make an issue.|
+
+## What's where?
+
+|Item|Location|
+|----|--------|
+|GPTK|`~/Library/Application Support/com.isaacmarovitz.Whisky/Libraries`|
+|Bottles|`~/Library/Containers/com.isaacmarovitz.Whisky/Bottles`|
+|Logs|`~/Library/Logs/com.isaacmarovitz.Whisky`|
+|WhiskyCMD|`/usr/local/bin/whisky`|
+
+---
+## Whisky or CrossOver?
+
+There are a lot of questions about which is better, here's an easy chart:
+
+|Feature|Whisky|CrossOver|
+|-------|------|---------|
+|Entirely Open-Source|✅|❌|
+|Free Updates Forever|✅|❌|
+|MSync|✅|✅|
+|ESync|✅|✅|
+|DirectX 12 Support|✅|✅|
+|Automated Installation|❌|✅|
+|Denuvo Support|❌|✅|
+|EA App Support|❌|✅|
+|Battle.net Support|❌|✅|
+|Ubisoft Connect Support|❌|✅|
+|OOTB GStreamer Support|❌|✅|
+|Wine 9 Support|❌|✅|
+|Proper Technical Support|❌|✅|
+|Future Updates to Wine|❌|✅|
+
+TLDR; CrossOver supports more apps than Whisky, and provides a more seamless user experience when Wine doesn't want to work out of the box. Which ever is best will depend on your needs and use case. 

--- a/wiki/Game-Support.md
+++ b/wiki/Game-Support.md
@@ -1,0 +1,112 @@
+Many games will work out of the box, but some are more tricky. Things that frequently cause issues with Wine are 3rd party launchers, anti-cheats, and online services. Some of these games have workarounds, and some do not.
+
+## Palworld
+- Install in Steam as normal
+- Right-click > Properties...
+- Add `-dx12` as launch option
+- Start Palworld from Steam as normal
+- When prompted about incompatible drivers, click `No`
+
+> [!NOTE] 
+> Some small graphical issues remain, such as black eye shaders, however the game is fully playable.
+
+## Cities: Skylines 2
+- Install in Steam as normal
+- Go back to Whisky, and press File > Kill All Bottles
+- On your bottle click `Winetricks...`
+- Install the following tricks in the following order\
+  `dotnet48 win10`
+
+> [!NOTE]
+> This will require user interaction and will likely take a rather long time to complete
+
+- Follow the instructions to patch your game here: https://github.com/manolz1/cities2-gptk-fix
+- Start Cities: Skylines 2 from Steam as normal
+
+> [!WARNING]
+> - Tabbing out will cause the game to become unresponsive and require it to be restarted. Do **not** change window focus while playing.
+> - Subsequent launches may fail to open the Paradox Launcher. This can be resolved temporarily by deleting the `Paradox Interactive` folder in `Program Files`. Reinstalling the launcher may also be required.
+
+## Counter-Strike 2
+- Install in Steam as normal
+- Right-click > Properties...
+- Add `-nojoy` as launch option
+
+> [!IMPORTANT]
+> This will disable controller input, but improves the FPS from 10 -> 100
+
+- Start CS2 from Steam as normal
+
+## Elden Ring
+- Install in Steam as normal
+- In Whisky, find `elden_ring.exe` in the Program list and press `Show in Finder`
+- Rename `start_protected_game.exe` to something else, and rename `elden_ring.exe` to `start_protected_game.exe`
+
+> [!IMPORTANT]
+> This will disable online play features
+
+- Start Elden Ring from Steam as normal
+
+## Diablo IV - Steam Version
+- Go to Config
+  - Change Windows Version to 19042 (Make sure to press enter to submit the change)
+  - Change Enhanced Sync mode to `ESync`
+- Install in Steam as normal
+- Install Diablo IV as normal
+- Delete `dstorage.dll` at `Program Files(x86)/steam/steamapps/common/Diablo IV`
+- Start Diablo IV as normal
+
+## Diablo IV - Battle.net Version
+- Go to Config
+  - Change Windows Version to 19042 (Make sure to press enter to submit the change)
+  - Change Enhanced Sync mode to `ESync`
+- Install Battle.net
+- On the Battle.net login screen, press the cog icon in the top right. Click on `Advanced`, and disable `Use hardware acceleration when available`
+- Go back to Whisky. Click on `File` > `Kill All Bottles`
+- Restart Battle.net
+- Login and install Diablo IV as normal
+
+## Star Wars Jedi: Fallen Order
+- Install in Steam as normal
+- In Whisky, find `SwGame-Win64-Shipping.exe` in the Program list and run it
+
+## Horizon Zero Dawn
+- Install Horizon Zero Dawn as normal
+- On your bottle click `Config` then `Open Registry Editor`
+- Navigate to `HKEY_LOCAL_MACHINE > Hardware > Description > System > CentralProcessor > 0`
+- Double-click to edit the `~MHz` key
+- Change the base to `Decimal` and type the value `1100`
+- Press `OK`, then close the Registry Editor
+- Start Horizon Zero Dawn as normal
+
+## Skyrim SE
+- Install in Steam as normal
+- In Whisky, find `SkyrimSELauncher.exe` in the Program list and press `Show in Finder`
+- Rename `SkyrimSELauncher.exe` to something else, and rename `SkyrimSE.exe` to `SkyrimSELauncher.exe`
+- On your bottle click `Winetricks...`
+- Install the following tricks in the following order\
+  `dotnet48 vcrun2019 dxvk1103 d3dx11_43 d3dcompiler_43 d3dcompiler_47 faudio`
+
+> [!NOTE]
+> This will require user interaction and will likely take a rather long time to complete
+
+- Start Skyrim from Steam as normal
+
+## Elite Dangerous
+- Install Steam
+- Install Elite Dangerous
+- Follow setup instructions here: https://github.com/rfvgyhn/min-ed-launcher#steam
+- Modify `gamesettings.json` in `users/crossover/AppData/Local/min-ed-launcher` and add the following line\
+  `"gameStartDelay": 5,`
+- Run Elite Dangerous as normal
+
+## Anime Game: Transportation Edition
+- Install anime game as normal
+- `Rm9sbG93IHRoZSBpbnN0cnVjdGlvbnMgYXQ6IGh0dHBzOi8vY29kZWJlcmcub3JnL21rcnN5bTEvamFkZWl0ZQ==`
+
+## Anime Game
+> [!NOTE]
+> It is recommended to use specific launchers to make the patching process easier.
+
+- Install anime game as normal
+- `Rm9sbG93IHRoZSBpbnN0cnVjdGlvbnMgYXQ6IGh0dHBzOi8vbm90YWJ1Zy5vcmcvS3JvY2svZGF3bg==`

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,5 @@
+## Welcome to the Whisky Wiki!
+
+Get started quickly with our [easy-to-follow quick-start guide](https://github.com/IsaacMarovitz/Whisky/wiki/A-Hitchhiker's-Guide-to-Whisky).
+
+Check the [Game Support page](https://github.com/IsaacMarovitz/Whisky/wiki/Game-Support) if you're looking for help with a specific game.


### PR DESCRIPTION
Due to GitHub's [way](https://docs.github.com/en/communities/documenting-your-project-with-wikis/changing-access-permissions-for-wikis#:~:text=only%20repository%20collaborators%20can%20edit%20a%20public%20repository's%20wiki%20by%20default,%20but%20you%20can%20allow%20anyone%20with%20an%20account%20on%20github.com%20to%20edit%20your%20wiki.) non-collaborator users can change wiki content if allowed through settings but it doesn't have any way of requiring an approval from the collaborators beforehand so I implemented a simple workaround through [GitHub Actions workflows](https://docs.github.com/en/actions/using-workflows) but it should be noted that it doesn't work two-way, which means if you change the content through web browser it won't sync the files. (I tried a couple solutions for syncing and tried to block changes that originates from the web browser as a Hail Mary but I couldn't find a proper way.)

**Beware** that in order for this workflow to work, there should be a [repository secret](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions?tool=webui#creating-secrets-for-a-repository) named **WIKI_TOKEN** that contains a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) that has the following structure:

- Classic token
   - public_repo
- Fine-grained token (recommended)
   - Repository access
   - Repository permissions
      - Contents - Read and write
      - Metadata - Read-only
      - Secrets - Read-only