### PR TITLE
add ability to double tap program to run

### DIFF
--- a/Whisky/Views/Programs/ProgramsView.swift
+++ b/Whisky/Views/Programs/ProgramsView.swift
@@ -190,6 +190,9 @@ struct ProgramItemView: View {
         .onHover { hover in
             showButtons = hover
         }
+        .onTapGesture(count: 2) {
+            program.run()
+        }
     }
 }
 


### PR DESCRIPTION
Provide a convenient way to directly run the program by double tapping instead of reaching for the run button each time.