### PR TITLE
WhiskyCmd: fix the run command

### DIFF
--- a/WhiskyCmd/Main.swift
+++ b/WhiskyCmd/Main.swift
@@ -176,6 +176,7 @@ extension Whisky {
             let url = URL(fileURLWithPath: path)
             let program = Program(url: url, bottle: bottle)
             program.runInTerminal()
+            RunLoop.main.run()
         }
     }
 

--- a/WhiskyKit/Sources/WhiskyKit/Extensions/Program+Extensions.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Extensions/Program+Extensions.swift
@@ -54,6 +54,7 @@ extension Program {
 
     public func runInTerminal() {
         let wineCmd = generateTerminalCommand().replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
 
         let script = """
         tell application "Terminal"


### PR DESCRIPTION
FIX: https://github.com/Whisky-App/Whisky/issues/1088
FIX: https://github.com/Whisky-App/Whisky/issues/1140

Fix two issues related to the `run` command:

1. `program.runInTerminal` would launch AppleScript asynchronously via a coroutine, but the main process had already exited, preventing it from starting. Added `RunLoop.main.run()` to make the main process wait until the execution is completed.
2. In `program.runInTerminal`, double quotes in the environment variables within `wineCmd` need to be escaped again.

**PS**: Sometimes, when the Whisky main UI runs for an extended period, it causes **High CPU** usage. To restore normal operation, the Whisky application itself needs to be closed (without closing the Wine-launched Windows application). The cause has not yet been identified.