### PR TITLE
Retain Pinned Programs on External Volumes

### DIFF
--- a/Whisky/Views/Bottle/Pins/PinView.swift
+++ b/Whisky/Views/Bottle/Pins/PinView.swift
@@ -92,7 +92,10 @@ struct PinView: View {
             self.image = await task.value
         }
         .onChange(of: name) {
-            if let index = bottle.settings.pins.firstIndex(where: { $0.url == pin.url }) {
+            if let index = bottle.settings.pins.firstIndex(where: {
+                let exists = FileManager.default.fileExists(atPath: pin.url?.path(percentEncoded: false) ?? "")
+                return $0.url == pin.url && exists
+            }) {
                 bottle.settings.pins[index].name = name
             }
         }

--- a/Whisky/Views/Programs/ProgramsView.swift
+++ b/Whisky/Views/Programs/ProgramsView.swift
@@ -123,13 +123,18 @@ struct ProgramsView: View {
 
     private func loadData() {
         loadPrograms()
-        blocklist = bottle.settings.blocklist
+        blocklist = bottle.settings.blocklist.filter({
+            return FileManager.default.fileExists(atPath: $0.path(percentEncoded: false))
+        })
     }
 
     private func loadPrograms() {
+        let programs = bottle.programs.filter({
+            return FileManager.default.fileExists(atPath: $0.url.path(percentEncoded: false))
+        })
         sortedPrograms = [
-            bottle.programs.pinned.sorted { $0.name < $1.name },
-            bottle.programs.unpinned.sorted { $0.name < $1.name }
+            programs.pinned.sorted { $0.name < $1.name },
+            programs.unpinned.sorted { $0.name < $1.name }
         ].flatMap { $0 }
     }
 }

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/BottleSettings.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/BottleSettings.swift
@@ -23,16 +23,25 @@ import os.log
 public struct PinnedProgram: Codable, Hashable, Equatable {
     public var name: String
     public var url: URL?
+    public var removable: Bool
 
     public init(name: String, url: URL) {
         self.name = name
         self.url = url
+        do {
+            let volume = try url.resourceValues(forKeys: [.volumeURLKey]).volume
+            self.removable = try !(volume?.resourceValues(forKeys: [.volumeIsInternalKey]).volumeIsInternal ?? false)
+        } catch {
+            print("error: \(error)")
+            self.removable = true
+        }
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
         self.url = try container.decodeIfPresent(URL.self, forKey: .url)
+        self.removable = try container.decodeIfPresent(Bool.self, forKey: .removable) ?? true
     }
 }
 

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/BottleSettings.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/BottleSettings.swift
@@ -40,7 +40,7 @@ public struct PinnedProgram: Codable, Hashable, Equatable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
         self.url = try container.decodeIfPresent(URL.self, forKey: .url)
-        self.removable = try container.decodeIfPresent(Bool.self, forKey: .removable) ?? true
+        self.removable = try container.decodeIfPresent(Bool.self, forKey: .removable) ?? false
     }
 }
 

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/BottleSettings.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/BottleSettings.swift
@@ -32,8 +32,7 @@ public struct PinnedProgram: Codable, Hashable, Equatable {
             let volume = try url.resourceValues(forKeys: [.volumeURLKey]).volume
             self.removable = try !(volume?.resourceValues(forKeys: [.volumeIsInternalKey]).volumeIsInternal ?? false)
         } catch {
-            print("error: \(error)")
-            self.removable = true
+            self.removable = false
         }
     }
 


### PR DESCRIPTION
This adds a property to bottle pins that notes whether or not a pinned program is on an internal drive. If not, it is "removable," such that if the drive is removed, the program will not display in the Bottle Pins or Installed Programs list, but is still read from and written to the metadata plist as if it still exists. If I've covered all my bases, the user should not be able to see or interact with any hidden programs. When Whisky is next opened or refreshed when the drive is plugged in, the programs will show again. If the drive is mounted but the program is not found, it is removed like usual.

This should build on #455, except in this case a Bottle can be on an internal drive and pin programs on external ones.