### PR TITLE
BugFix: gracefully clean up pipe objects to fix high CPUe

### DIFF
--- a/WhiskyKit/Sources/WhiskyKit/Extensions/Process+Extensions.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Extensions/Process+Extensions.swift
@@ -75,6 +75,8 @@ public extension Process {
 
             terminationHandler = { (process: Process) in
                 do {
+                    pipe.fileHandleForReading.readabilityHandler = nil
+                    errorPipe.fileHandleForReading.readabilityHandler = nil
                     _ = try pipe.fileHandleForReading.readToEnd()
                     _ = try errorPipe.fileHandleForReading.readToEnd()
                     try fileHandle?.close()


### PR DESCRIPTION
CLOSE #917

Analysis of CPU profile using **Instruments** revealed that `availableData` was consistently empty during `readabilityHandler` processing of the pipe. 

<img width="785" alt="截屏2025-05-09 09 35 21" src="https://github.com/user-attachments/assets/7721ae75-cca3-4e0c-96e6-8c75ecc4eea7" />
    
This suggests the pipe was already closed, causing the handler to continuously receive **EOF**.

According to Apple's official documentation for [readabilityHandler](https://developer.apple.com/documentation/foundation/pipe/1408980-readabilityhandler), the handler should be actively set to nil when no longer needed.